### PR TITLE
Fix: reconcile incorrectly nulls falsey values

### DIFF
--- a/lib/BaseController.js
+++ b/lib/BaseController.js
@@ -487,7 +487,7 @@ module.exports = class BaseController {
       path.push(key);
       const configPathValue = objectPath.get(config, path);
       // if config does not have the lastApplied path, make sure to set lastApplied path in config to null.
-      if (!configPathValue) {
+      if (configPathValue === undefined) {
         objectPath.set(config, path, null);
         // elseif (lastApplied[key] is not null/undefined and it is an object we should recurse
       } else if ((lastApplied[key] && lastApplied[key].constructor === Object)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2097,9 +2097,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "version": "1.3.8",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-alchemy-containers-team-npm-virtual/ini/-/ini-1.3.8.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fini%2F-%2Fini-1.3.8.tgz",
+      "integrity": "sha1-op2kJbSIBvNHZ6Tvzjlyaa8oQyw=",
       "dev": true
     },
     "interpret": {


### PR DESCRIPTION
reconcilefileds should only set field to null when lastapplied path exists and new path is undefined.