### PR TITLE
Fix: whitespace removed from jsonString

### DIFF
--- a/lib/FetchEnvs.js
+++ b/lib/FetchEnvs.js
@@ -96,9 +96,15 @@ module.exports = class FetchEnvs {
           result = JSON.parse(result);
           break;
         case 'jsonString':
-          // result = JSON.stringify(result);
-          // result = result.slice(1, result.length - 1);
-          result = result.replace(/\n/g, '').replace(/"/g, '\\"').replace(/\s+/g, '');
+          // Stringify the jsonstring. This has the effect of double escaping the json, so that
+          // when we go to parse the final template to apply it to kube, it doesnt mistakenly
+          // turn our jsonString into actual json.
+          result = JSON.stringify(result);
+          // JSON.stringify adds quotes around the newly created json string. Kube forces us
+          // to wrap out curly braces in quotes so that it wont error on our templates. In order
+          // to avoid having 2 double quotes around the result, we need to remove the stringify
+          // quotes. slice(start of slice, end of slice)
+          result = result.slice(1, result.length - 1);
           break;
         case 'base64':
           result = new Buffer(result).toString('base64');

--- a/package-lock.json
+++ b/package-lock.json
@@ -2097,9 +2097,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "version": "1.3.8",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-alchemy-containers-team-npm-virtual/ini/-/ini-1.3.8.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fini%2F-%2Fini-1.3.8.tgz",
+      "integrity": "sha1-op2kJbSIBvNHZ6Tvzjlyaa8oQyw=",
       "dev": true
     },
     "interpret": {


### PR DESCRIPTION
Dont remove all whitespaces from the json string. Switching to using json.stringify so we dont have to worry about processing the json correctly. Still have to remove the quotes stringify adds to account for having to put quotes around our template curly braces.