### PR TITLE
feat: allow razeedeploy to impersonate user

### DIFF
--- a/lib/BaseController.js
+++ b/lib/BaseController.js
@@ -37,14 +37,6 @@ module.exports = class BaseController {
       name: this._name,
       namespace: this._namespace
     });
-    // TODO: https://github.com/razee-io/razeedeploy-core/issues/189
-    let impersonateUser = objectPath.get(this._data, 'object.spec.clusterAuth.impersonateUser', 'razeedeploy');
-    if (impersonateUser !== 'razeedeploy' && this.namespace === 'razeedeploy') {
-      this._kubeResourceMeta.addHeader('Impersonate-User', impersonateUser);
-    } else {
-      impersonateUser = 'razeedeploy';
-      objectPath.set(this._data, 'object.spec.clusterAuth.impersonateUser', impersonateUser);
-    }
 
     this._status = {}; // to be removed
     this._children = {};
@@ -92,6 +84,18 @@ module.exports = class BaseController {
       if (!(this._data || this._data.type)) {
         throw Error('Unrecognized object received from watch event');
       }
+
+      // TODO: https://github.com/razee-io/razeedeploy-core/issues/189
+      let impersonateUser = objectPath.get(this._data, 'object.spec.clusterAuth.impersonateUser', 'false');
+      if (impersonateUser !== 'razeedeploy') {
+        if (impersonateUser !== 'false' && this.namespace === 'razeedeploy') {
+          this._kubeResourceMeta.addHeader('Impersonate-User', impersonateUser);
+        } else {
+          impersonateUser = 'razeedeploy';
+          return await this.patchSelf({ 'spec': { 'clusterAuth': { 'impersonateUser': impersonateUser } } });
+        }
+      }
+
       this._logger.info(`${this._data.type} event received ${this.selfLink} ${objectPath.get(this._data, 'object.metadata.resourceVersion')}`);
       let clusterLocked = await this._cluster_locked();
       if (clusterLocked) {

--- a/lib/BaseController.js
+++ b/lib/BaseController.js
@@ -38,14 +38,12 @@ module.exports = class BaseController {
       namespace: this._namespace
     });
     // TODO: https://github.com/razee-io/razeedeploy-core/issues/189
-    let impersonateUser = objectPath.get(this._data, 'object.spec.clusterAuth.impersonateUser');
-    if (impersonateUser !== undefined) {
-      if (this.namespace === 'razeedeploy') {
-        this._kubeResourceMeta.addHeader('Impersonate-User', impersonateUser);
-      } else {
-        impersonateUser = false;
-        objectPath.set(this._data, 'object.spec.clusterAuth.impersonateUser', impersonateUser);
-      }
+    let impersonateUser = objectPath.get(this._data, 'object.spec.clusterAuth.impersonateUser', 'razeedeploy');
+    if (impersonateUser !== 'razeedeploy' && this.namespace === 'razeedeploy') {
+      this._kubeResourceMeta.addHeader('Impersonate-User', impersonateUser);
+    } else {
+      impersonateUser = 'razeedeploy';
+      objectPath.set(this._data, 'object.spec.clusterAuth.impersonateUser', impersonateUser);
     }
 
     this._status = {}; // to be removed

--- a/lib/BaseController.js
+++ b/lib/BaseController.js
@@ -44,6 +44,7 @@ module.exports = class BaseController {
         this._kubeResourceMeta.addHeader('Impersonate-User', impersonateUser);
       } else {
         impersonateUser = false;
+        objectPath.set(this._data, 'object.spec.clusterAuth.impersonateUser', impersonateUser);
       }
     }
 

--- a/lib/BaseController.js
+++ b/lib/BaseController.js
@@ -37,6 +37,16 @@ module.exports = class BaseController {
       name: this._name,
       namespace: this._namespace
     });
+    // TODO: https://github.com/razee-io/razeedeploy-core/issues/189
+    let impersonateUser = objectPath.get(this._data, 'object.spec.clusterAuth.impersonateUser');
+    if (impersonateUser !== undefined) {
+      if (this.namespace === 'razeedeploy') {
+        this._kubeResourceMeta.addHeader('Impersonate-User', impersonateUser);
+      } else {
+        impersonateUser = false;
+      }
+    }
+
     this._status = {}; // to be removed
     this._children = {};
     this._razeeLogHashes = [];

--- a/lib/BaseDownloadController.js
+++ b/lib/BaseDownloadController.js
@@ -80,7 +80,7 @@ module.exports = class BaseDownloadController extends CompositeController {
         let res = await this.download(reqOpt);
         if (res.statusCode >= 200 && res.statusCode < 300) {
           this.log.debug(`Download ${res.statusCode} ${url}`);
-          file = yaml.safeLoadAll(res.body);
+          file = yaml.loadAll(res.body);
           if (Array.isArray(file) && file.length == 1) { file = file[0]; }
 
           // TODO if last-modified doesnt exist try etag
@@ -186,7 +186,7 @@ module.exports = class BaseDownloadController extends CompositeController {
           try {
             objectPath.set(headers, [hKey], await this._getSecretData(secretName, secretKey, secretNamespace));
           } catch (e) {
-            throw Error(`Unable to fetch header secret data. { name: ${secretName}, namespace: ${secretNamespace }, key: ${secretKey} }: ${objectPath.get(e, 'error.message')}`);
+            throw Error(`Unable to fetch header secret data. { name: ${secretName}, namespace: ${secretNamespace}, key: ${secretKey} }: ${objectPath.get(e, 'error.message')}`);
           }
         }
       }

--- a/lib/CompositeController.js
+++ b/lib/CompositeController.js
@@ -141,10 +141,7 @@ module.exports = class CompositeController extends BaseController {
       };
     }
 
-    // TODO: until we have better user validation, to see if a user should be allowed to create a 
-    // resource that impersonates another user, don't allow user impersonation outside of the razeedeploy namespace.
-    // For now, cluster owners should be aware that they should prevent their users from creating
-    // razeedeploy resources in the razeedeploy namespace, if they want to prevent them from using user-impersonation.
+    // TODO: https://github.com/razee-io/razeedeploy-core/issues/189
     let impersonateUser = objectPath.get(this.data, 'object.spec.clusterAuth.impersonateUser');
     if (impersonateUser !== undefined) {
       if (this.namespace === 'razeedeploy') {

--- a/lib/CompositeController.js
+++ b/lib/CompositeController.js
@@ -142,13 +142,11 @@ module.exports = class CompositeController extends BaseController {
     }
 
     // TODO: https://github.com/razee-io/razeedeploy-core/issues/189
-    let impersonateUser = objectPath.get(this.data, 'object.spec.clusterAuth.impersonateUser');
-    if (impersonateUser !== undefined) {
-      if (this.namespace === 'razeedeploy') {
-        krm.addHeader('Impersonate-User', impersonateUser);
-      } else {
-        impersonateUser = false;
-      }
+    let impersonateUser = objectPath.get(this.data, 'object.spec.clusterAuth.impersonateUser', 'razeedeploy');
+    if (impersonateUser !== 'razeedeploy' && this.namespace === 'razeedeploy') {
+      krm.addHeader('Impersonate-User', impersonateUser);
+    } else {
+      impersonateUser = 'razeedeploy';
     }
 
     let res;

--- a/lib/CompositeController.js
+++ b/lib/CompositeController.js
@@ -141,6 +141,19 @@ module.exports = class CompositeController extends BaseController {
       };
     }
 
+    // TODO: until we have better user validation, to see if a user should be allowed to create a 
+    // resource that impersonates another user, don't allow user impersonation outside of the razeedeploy namespace.
+    // For now, cluster owners should be aware that they should prevent their users from creating
+    // razeedeploy resources in the razeedeploy namespace, if they want to prevent them from using user-impersonation.
+    let impersonateUser = objectPath.get(this.data, 'object.spec.clusterAuth.impersonateUser');
+    if (impersonateUser !== undefined) {
+      if (this.namespace === 'razeedeploy') {
+        krm.addHeader('Impersonate-User', impersonateUser);
+      } else {
+        impersonateUser = false;
+      }
+    }
+
     let res;
     let reconcile = objectPath.get(child, ['metadata', 'labels', 'deploy.razee.io/Reconcile']) ||
       objectPath.get(child, ['metadata', 'labels', 'kapitan.razee.io/Reconcile'], this.reconcileDefault);
@@ -164,7 +177,7 @@ module.exports = class CompositeController extends BaseController {
         default:
           res = await this.apply(krm, child);
       }
-      await this.addChildren({ uid: childUid, selfLink: childUri, 'deploy.razee.io/Reconcile': reconcile });
+      await this.addChildren({ uid: childUid, selfLink: childUri, 'deploy.razee.io/Reconcile': reconcile, 'Impersonate-User': impersonateUser });
       this.log.info(`${mode} ${res.statusCode} ${childUri}`);
     } catch (e) {
       res = e;


### PR DESCRIPTION
this is the first step in better authentication around razee resources. this feature allows razeedeploy resources to impersonate a user that is specified in the spec.

In the future we will need much better guard rails to prevent users from impersonating others, but for now its not much different then them just allowing razeedeploy do it.