### PR TITLE
fix: dont null whole objects if a resource stops creating it

### DIFF
--- a/lib/BaseController.js
+++ b/lib/BaseController.js
@@ -505,7 +505,8 @@ module.exports = class BaseController {
       path.push(key);
       const configPathValue = objectPath.get(config, path);
       // if config does not have the lastApplied path, make sure to set lastApplied path in config to null.
-      if (configPathValue === undefined) {
+      // we must avoid nulling any "objects", and only nulling "leafs", as we could delete other fields unintentionally.
+      if (configPathValue === undefined && lastApplied[key].constructor !== Object) {
         objectPath.set(config, path, null);
         // elseif (lastApplied[key] is not null/undefined and it is an object we should recurse
       } else if ((lastApplied[key] && lastApplied[key].constructor === Object)) {

--- a/lib/BaseTemplateController.js
+++ b/lib/BaseTemplateController.js
@@ -45,7 +45,12 @@ module.exports = class BaseTemplateController extends CompositeController {
         let kind = objectPath.get(rsp, 'body.details.kind') || objectPath.get(templates, [i, 'kind']);
         let group = objectPath.get(rsp, 'body.details.group') || objectPath.get(templates, [i, 'apiVersion']);
         let name = objectPath.get(rsp, 'body.details.name') || objectPath.get(templates, [i, 'metadata', 'name']);
-        return Promise.reject(`kind.group: "${kind}.${group}" name: "${name}" status "${rsp.statusCode} ${objectPath.get(rsp, 'body.reason', '')}".. see logs for details`);
+        let msg = `kind.group: "${kind}.${group}" name: "${name}"`;
+        if (rsp.statusCode) {
+          return Promise.reject(`${msg} statusCode: "${rsp.statusCode} message: ${objectPath.get(rsp, 'body.message')}"`);
+        } else {
+          return Promise.reject(`${msg} ${rsp.toString()}`);
+        }
       }
     }
     await this.reconcileChildren();


### PR DESCRIPTION
this bug was found when a user had a MTP create a resource with an annotation section defined. They then updated their mtp and no longer defined the annotation section. This caused the reconcileFields function to null the entire annotations section. We then tell objectPath to null out the old kapitan/last-applied annotation, and it promply fails because it cant set a value to a null field.

Not only will the commit fix that user issue, it will also prevent us destroying other items in a resource that a user may stop defining but may not what the whole thing deleted (like some default set by kube or a third party)