### PR TITLE
fix: cant set null if user already set value to null

### DIFF
--- a/lib/BaseController.js
+++ b/lib/BaseController.js
@@ -508,8 +508,8 @@ module.exports = class BaseController {
       // we must avoid nulling any "objects", and only nulling "leafs", as we could delete other fields unintentionally.
       if (configPathValue === undefined && lastApplied[key].constructor !== Object) {
         objectPath.set(config, path, null);
-        // elseif (lastApplied[key] is not null/undefined and it is an object we should recurse
-      } else if ((lastApplied[key] && lastApplied[key].constructor === Object)) {
+        // elseif lastApplied[key] is not null/undefined, and it is an object, and configPathValue is not already set null by user, then we should recurse
+      } else if ((lastApplied[key] && lastApplied[key].constructor === Object && configPathValue !== null)) {
         this.reconcileFields(config, lastApplied[key], path);
       } // else path exists both in lastApplied and new config, no need to alter it
     });


### PR DESCRIPTION
dont try to null object child values if the parent is already set to null.
{test:{ values: 123}}
=>
{test: null}
we will avoid trying to set values to null because test is already null