### PR TITLE
Add metadata showing upcoming changes on debug'd resources

### DIFF
--- a/lib/BaseController.js
+++ b/lib/BaseController.js
@@ -544,7 +544,17 @@ module.exports = class BaseController {
       let debug = objectPath.get(liveResource, ['metadata', 'labels', 'deploy.razee.io/debug']) ||
         objectPath.get(liveResource, ['metadata', 'labels', 'kapitan.razee.io/debug'], 'false');
       if (debug.toLowerCase() === 'true') {
+        this.log.warn(`${uri}: Debug enabled on resource, adding deploy.razee.io/pending-configuration`);
+        if (objectPath.get(file, ['metadata', 'annotations']) === null) {
+          objectPath.set(file, ['metadata', 'annotations'], {});
+        }
+        await this.patchSelf({ metadata: { annotations: { 'deploy.razee.io/pending-configuration': JSON.stringify(file) } } });
         return { statusCode: 200, body: liveResource };
+      } else {
+        let pendingApply = objectPath.get(liveResource, ['metadata', 'annotations', 'deploy.razee.io/pending-configuration']);
+        if (pendingApply) {
+          objectPath.set(file, ['metadata', 'annotations', 'deploy.razee.io/pending-configuration'], null);
+        }
       }
       let lastApplied = objectPath.get(liveResource, ['metadata', 'annotations', 'deploy.razee.io/last-applied-configuration']) ||
         objectPath.get(liveResource, ['metadata', 'annotations', 'kapitan.razee.io/last-applied-configuration']);

--- a/lib/BaseController.js
+++ b/lib/BaseController.js
@@ -544,12 +544,10 @@ module.exports = class BaseController {
       let debug = objectPath.get(liveResource, ['metadata', 'labels', 'deploy.razee.io/debug']) ||
         objectPath.get(liveResource, ['metadata', 'labels', 'kapitan.razee.io/debug'], 'false');
       if (debug.toLowerCase() === 'true') {
-        this.log.warn(`${uri}: Debug enabled on resource, adding deploy.razee.io/pending-configuration`);
-        if (objectPath.get(file, ['metadata', 'annotations']) === null) {
-          objectPath.set(file, ['metadata', 'annotations'], {});
-        }
-        await this.patchSelf({ metadata: { annotations: { 'deploy.razee.io/pending-configuration': JSON.stringify(file) } } });
-        return { statusCode: 200, body: liveResource };
+        this.log.warn(`${uri}: Debug enabled on resource: skipping modifying resource - adding annotation deploy.razee.io/pending-configuration.`);
+        let patchObject = { metadata: { annotations: { 'deploy.razee.io/pending-configuration': JSON.stringify(file) } } };
+        let res = await krm.mergePatch(name, namespace, patchObject);
+        return { statusCode: 200, body: res };
       } else {
         let pendingApply = objectPath.get(liveResource, ['metadata', 'annotations', 'deploy.razee.io/pending-configuration']);
         if (pendingApply) {


### PR DESCRIPTION
The current common model in k8s of providing a last-applied-configuration gave me an idea for addressing #156.  Basically, instead of trying to find some way to expose the configuration via an API or the logs, put it on the resources now.  

Yes, the con here is that you are editing the resource, but only a piece of metadata.

Anyone could write a wrapper to extract this and compare to the existing to identify what is going to change.

This does not address the following:

* How cluster locking works.  because it would be really good to also have this information for when a cluster is locked, cause the scope of change is much larger.

* If you are doing nested dependencies, such as locking a configmap that affects a mustache template, then only the configmap would get this annotation.  Not really a reasonable way to expect razee to follow that chain.