### PR TITLE
fix: allow fetchenvs to traverse multi-level env paths

### DIFF
--- a/lib/FetchEnvs.js
+++ b/lib/FetchEnvs.js
@@ -217,14 +217,14 @@ module.exports = class FetchEnvs {
     // removes the '.env' or '.envFrom' if the paths ends in either
     path = path.replace(/^\.*|\.*$|(\.envFrom\.*$)|(\.env\.*$)/g, '');
 
-    let envFrom = this.data?.object?.[path]?.envFrom ?? [];
+    let envFrom = objectPath.get(this.data, `object.${path}.envFrom`, []);
     envFrom = await this.#processEnvFrom(envFrom);
     for (const env of envFrom) {
       const data = env?.data ?? {};
       result = { ...result, ...data };
     }
 
-    const env = this.data?.object?.[path]?.env ?? [];
+    const env = objectPath.get(this.data, `object.${path}.env`, []);
     return (await this.#processEnv(env)).reduce(reduceEnv, result);
   }
 };
@@ -306,3 +306,33 @@ function typeCast(value, type) {
     }
   }
 }
+
+const objectPath = {
+  get: function (obj, path, def) {
+    if (typeof path === 'string') {
+      const output = [];
+      path.split('.').forEach(function (item) {
+        // Split to an array with bracket notation
+        item.split(/\[([^}]+)\]/g).forEach(function (key) {
+          // Push to the new array
+          if (key.length > 0) {
+            output.push(key);
+          }
+        });
+      });
+      path = output;
+    }
+
+    // Cache the current object
+    var current = obj;
+    // For each item in the path, dig into the object
+    for (var i = 0; i < path.length; i++) {
+      // If the item isn't found, return the default (or null)
+      if (!current[path[i]]) return def;
+      // Otherwise, update the current  value
+      current = current[path[i]];
+    }
+
+    return current;
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -2849,9 +2849,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "devOptional": true
     },
     "node_modules/mkdirp": {
@@ -6889,9 +6889,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "devOptional": true
     },
     "mkdirp": {


### PR DESCRIPTION
path can be any length, that may or may not exist. so need a way to fetch env/envFrom given the user's defined path.