### PR TITLE
fix: don't throw error if json value is empty

### DIFF
--- a/lib/FetchEnvs.js
+++ b/lib/FetchEnvs.js
@@ -288,7 +288,10 @@ function typeCast(value, type) {
       return (value.toLowerCase() === 'true');
     }
     case 'json': {
-      return JSON.parse(value);
+      if (value) {
+        return JSON.parse(value);
+      }
+      return {}
     }
     case 'jsonString': {
       // Stringify the jsonstring. This has the effect of double escaping the json, so that

--- a/test/fetchEnvs-test-scenarios/env_scenarios.json
+++ b/test/fetchEnvs-test-scenarios/env_scenarios.json
@@ -209,5 +209,19 @@
       "name": "string_env",
       "value": "my value"
     }
+  ],
+  "scenario12": [
+    {
+      "name": "json_env",
+      "valueFrom": {
+        "configMapKeyRef": {
+          "namespace": "razeedeploy",
+          "name": "supposed-to-be-json-but-empty",
+          "key": "json",
+          "type": "json"
+        }
+      }
+    }
   ]
 }
+

--- a/test/fetchEnvs-test-scenarios/sampleData.json
+++ b/test/fetchEnvs-test-scenarios/sampleData.json
@@ -94,6 +94,17 @@
         "number": "5",
         "string": "baz"
       }
+    },
+    {
+      "apiVersion": "v1",
+      "kind": "ConfigMap",
+      "metadata": {
+        "name": "supposed-to-be-json-but-empty",
+        "namespace": "razeedeploy"
+      },
+      "data": {
+        "json": ""
+      }
     }
   ],
   "Secret": [

--- a/test/fetchEnvs-tests.js
+++ b/test/fetchEnvs-tests.js
@@ -389,6 +389,13 @@ describe('fetchEnvs', function () {
 
         assert.deepEqual(view.string_env, 'my value', 'should fetch config as expected');
       });
+      it('env_scenarios.json/scenario12: supposed to be json, but empty', async function () {
+        controllerObject.data.object.spec.env = (await fs.readJSON(`${__dirname}/fetchEnvs-test-scenarios/env_scenarios.json`)).scenario12;
+        const fetchEnvs = new FetchEnvs(controllerObject);
+        const view = await fetchEnvs.get('spec');
+
+        assert.deepEqual(view.json_env, {}, 'should return empty object instead of error');
+      });
     });
 
     // #get() envFrom + env


### PR DESCRIPTION
Currently `typeCast` will attempt to `JSON.parse` a value even if it's empty. Rather than throwing a parse error, an empty object should just be returned. This allows for the case of a JSON value with an empty default without needing to specify the value as `"{}"`