### PR TITLE
remove impersonation restriction

### DIFF
--- a/lib/BaseController.js
+++ b/lib/BaseController.js
@@ -84,9 +84,22 @@ module.exports = class BaseController {
         throw Error('Unrecognized object received from watch event');
       }
 
-      let impersonateUser = objectPath.get(this._data, 'object.spec.clusterAuth.impersonateUser', 'razeedeploy');
-      if (impersonateUser != 'razeedeploy') {
-        this._kubeResourceMeta.addHeader('Impersonate-User', impersonateUser);
+      let impersonateUser = objectPath.get(this._data, 'object.spec.clusterAuth.impersonateUser', 'false');
+      let impersonationEnabled = await this._impersonation_enabled();
+      if (impersonateUser != 'false') {
+        if (impersonateUser != 'razeedeploy') {
+          if (impersonationEnabled) {
+            this._kubeResourceMeta.addHeader('Impersonate-User', impersonateUser);
+          }
+          else {
+            if (this.namespace === 'razeedeploy') {
+              this._kubeResourceMeta.addHeader('Impersonate-User', impersonateUser);
+            }
+          }
+        }
+      }
+      else {
+        return await this.patchSelf({ 'spec': { 'clusterAuth': { 'impersonateUser': 'razeedeploy' } } });
       }
 
       this._logger.info(`${this._data.type} event received ${this.selfLink} ${objectPath.get(this._data, 'object.metadata.resourceVersion')}`);
@@ -222,6 +235,17 @@ module.exports = class BaseController {
       lockCluster = lockCluster.trim().toLowerCase();
     }
     return (lockCluster == 'true');
+  }
+
+  async _impersonation_enabled() {
+    let enableImpersonation = 'false';
+    let enableImpersonationPath = './config/enable-impersonation';
+    let exists = await fs.pathExists(enableImpersonationPath);
+    if (exists) {
+      enableImpersonation = await fs.readFile(enableImpersonationPath, 'utf8');
+      enableImpersonation = enableImpersonation.trim().toLowerCase();
+    }
+    return (enableImpersonation == 'true');
   }
 
   _computeDataHash(resource) {

--- a/lib/BaseController.js
+++ b/lib/BaseController.js
@@ -83,7 +83,7 @@ module.exports = class BaseController {
       if (!(this._data || this._data.type)) {
         throw Error('Unrecognized object received from watch event');
       }
-      
+
       let res = await this.preprocessImpersonation();
       if (res != null) {
         return res;
@@ -143,7 +143,7 @@ module.exports = class BaseController {
     if (impersonationEnabled || this.namespace === 'razeedeploy') {
       krm.addHeader('Impersonate-User', impersonateUser);
     } else {
-      impersonateUser = 'razeedeploy'
+      impersonateUser = 'razeedeploy';
     }
 
     return impersonateUser;

--- a/lib/BaseController.js
+++ b/lib/BaseController.js
@@ -83,9 +83,14 @@ module.exports = class BaseController {
       if (!(this._data || this._data.type)) {
         throw Error('Unrecognized object received from watch event');
       }
-
-      await this.preprocessImpersonation();
-      await this.processImpersonation(this._kubeResourceMeta);
+      
+      let res = await this.preprocessImpersonation();
+      if (res != null) {
+        return res;
+      }
+      else {
+        await this.processImpersonation(this._kubeResourceMeta);
+      }
 
       this._logger.info(`${this._data.type} event received ${this.selfLink} ${objectPath.get(this._data, 'object.metadata.resourceVersion')}`);
       let clusterLocked = await this._cluster_locked();
@@ -118,11 +123,14 @@ module.exports = class BaseController {
   }
 
   async preprocessImpersonation() {
+    let res = null;
     let impersonationEnabled = await this._impersonation_enabled();
     let impersonateUser = objectPath.get(this.data, 'object.spec.clusterAuth.impersonateUser', 'false');
     if (impersonateUser === 'false' || (!impersonationEnabled && impersonateUser != 'razeedeploy' && this.namespace != 'razeedeploy')) {
       return await this.patchSelf({ 'spec': { 'clusterAuth': { 'impersonateUser': 'razeedeploy' } } });
     }
+
+    return res;
   }
 
   async processImpersonation(krm) {

--- a/lib/BaseController.js
+++ b/lib/BaseController.js
@@ -85,7 +85,9 @@ module.exports = class BaseController {
       }
 
       let impersonateUser = objectPath.get(this._data, 'object.spec.clusterAuth.impersonateUser', 'razeedeploy');
-      this._kubeResourceMeta.addHeader('Impersonate-User', impersonateUser);
+      if (impersonateUser != 'razeedeploy') {
+        this._kubeResourceMeta.addHeader('Impersonate-User', impersonateUser);
+      }
 
       this._logger.info(`${this._data.type} event received ${this.selfLink} ${objectPath.get(this._data, 'object.metadata.resourceVersion')}`);
       let clusterLocked = await this._cluster_locked();

--- a/lib/BaseController.js
+++ b/lib/BaseController.js
@@ -140,13 +140,10 @@ module.exports = class BaseController {
     }
 
     let impersonationEnabled = await this._impersonation_enabled();
-    if (impersonationEnabled) {
+    if (impersonationEnabled || this.namespace === 'razeedeploy') {
       krm.addHeader('Impersonate-User', impersonateUser);
-    }
-    else {
-      if (this.namespace === 'razeedeploy') {
-        krm.addHeader('Impersonate-User', impersonateUser);
-      }
+    } else {
+      impersonateUser = 'razeedeploy'
     }
 
     return impersonateUser;

--- a/lib/BaseController.js
+++ b/lib/BaseController.js
@@ -84,23 +84,8 @@ module.exports = class BaseController {
         throw Error('Unrecognized object received from watch event');
       }
 
-      let impersonateUser = objectPath.get(this._data, 'object.spec.clusterAuth.impersonateUser', 'false');
-      let impersonationEnabled = await this._impersonation_enabled();
-      if (impersonateUser != 'false') {
-        if (impersonateUser != 'razeedeploy') {
-          if (impersonationEnabled) {
-            this._kubeResourceMeta.addHeader('Impersonate-User', impersonateUser);
-          }
-          else {
-            if (this.namespace === 'razeedeploy') {
-              this._kubeResourceMeta.addHeader('Impersonate-User', impersonateUser);
-            }
-          }
-        }
-      }
-      else {
-        return await this.patchSelf({ 'spec': { 'clusterAuth': { 'impersonateUser': 'razeedeploy' } } });
-      }
+      await this.preprocessImpersonation();
+      await this.processImpersonation(this._kubeResourceMeta);
 
       this._logger.info(`${this._data.type} event received ${this.selfLink} ${objectPath.get(this._data, 'object.metadata.resourceVersion')}`);
       let clusterLocked = await this._cluster_locked();
@@ -130,6 +115,33 @@ module.exports = class BaseController {
         this._logger.error(e);
       }
     }
+  }
+
+  async preprocessImpersonation() {
+    let impersonationEnabled = await this._impersonation_enabled();
+    let impersonateUser = objectPath.get(this.data, 'object.spec.clusterAuth.impersonateUser', 'false');
+    if (impersonateUser === 'false' || (!impersonationEnabled && impersonateUser != 'razeedeploy' && this.namespace != 'razeedeploy')) {
+      return await this.patchSelf({ 'spec': { 'clusterAuth': { 'impersonateUser': 'razeedeploy' } } });
+    }
+  }
+
+  async processImpersonation(krm) {
+    let impersonateUser = objectPath.get(this.data, 'object.spec.clusterAuth.impersonateUser', 'razeedeploy');
+    if (impersonateUser === 'razeedeploy') {
+      return impersonateUser;
+    }
+
+    let impersonationEnabled = await this._impersonation_enabled();
+    if (impersonationEnabled) {
+      krm.addHeader('Impersonate-User', impersonateUser);
+    }
+    else {
+      if (this.namespace === 'razeedeploy') {
+        krm.addHeader('Impersonate-User', impersonateUser);
+      }
+    }
+
+    return impersonateUser;
   }
 
   errorHandler(err) {

--- a/lib/BaseController.js
+++ b/lib/BaseController.js
@@ -85,16 +85,8 @@ module.exports = class BaseController {
         throw Error('Unrecognized object received from watch event');
       }
 
-      // TODO: https://github.com/razee-io/razeedeploy-core/issues/189
-      let impersonateUser = objectPath.get(this._data, 'object.spec.clusterAuth.impersonateUser', 'false');
-      if (impersonateUser !== 'razeedeploy') {
-        if (impersonateUser !== 'false' && this.namespace === 'razeedeploy') {
-          this._kubeResourceMeta.addHeader('Impersonate-User', impersonateUser);
-        } else {
-          impersonateUser = 'razeedeploy';
-          return await this.patchSelf({ 'spec': { 'clusterAuth': { 'impersonateUser': impersonateUser } } });
-        }
-      }
+      let impersonateUser = objectPath.get(this._data, 'object.spec.clusterAuth.impersonateUser', 'razeedeploy');
+      this._kubeResourceMeta.addHeader('Impersonate-User', impersonateUser);
 
       this._logger.info(`${this._data.type} event received ${this.selfLink} ${objectPath.get(this._data, 'object.metadata.resourceVersion')}`);
       let clusterLocked = await this._cluster_locked();

--- a/lib/BaseDownloadController.js
+++ b/lib/BaseDownloadController.js
@@ -236,5 +236,4 @@ module.exports = class BaseDownloadController extends CompositeController {
     // Do not send back anything you dont want applied to kube
     throw Error('Override BaseDownloadController.download in the subclass.');
   }
-
 };

--- a/lib/BaseTemplateController.js
+++ b/lib/BaseTemplateController.js
@@ -61,5 +61,4 @@ module.exports = class BaseTemplateController extends CompositeController {
     // output: Array - processed templates ready to be applied
     throw Error('Override BaseTemplateController.processTemplate in the subclass.');
   }
-
 };

--- a/lib/CompositeController.js
+++ b/lib/CompositeController.js
@@ -141,13 +141,8 @@ module.exports = class CompositeController extends BaseController {
       };
     }
 
-    // TODO: https://github.com/razee-io/razeedeploy-core/issues/189
     let impersonateUser = objectPath.get(this.data, 'object.spec.clusterAuth.impersonateUser', 'razeedeploy');
-    if (impersonateUser !== 'razeedeploy' && this.namespace === 'razeedeploy') {
-      krm.addHeader('Impersonate-User', impersonateUser);
-    } else {
-      impersonateUser = 'razeedeploy';
-    }
+    krm.addHeader('Impersonate-User', impersonateUser);
 
     let res;
     let reconcile = objectPath.get(child, ['metadata', 'labels', 'deploy.razee.io/Reconcile']) ||
@@ -245,6 +240,4 @@ module.exports = class CompositeController extends BaseController {
     this.log.debug(`Delete ${res.statusCode} ${opt.uri || opt.url}`);
     return { statusCode: res.statusCode, body: res.body };
   }
-
-
 };

--- a/lib/CompositeController.js
+++ b/lib/CompositeController.js
@@ -141,7 +141,9 @@ module.exports = class CompositeController extends BaseController {
     }
 
     let impersonateUser = objectPath.get(this.data, 'object.spec.clusterAuth.impersonateUser', 'razeedeploy');
-    krm.addHeader('Impersonate-User', impersonateUser);
+    if (impersonateUser != 'razeedeploy') {
+      krm.addHeader('Impersonate-User', impersonateUser);
+    }
 
     let res;
     let reconcile = objectPath.get(child, ['metadata', 'labels', 'deploy.razee.io/Reconcile'], this.reconcileDefault);

--- a/lib/CompositeController.js
+++ b/lib/CompositeController.js
@@ -140,10 +140,7 @@ module.exports = class CompositeController extends BaseController {
       };
     }
 
-    let impersonateUser = objectPath.get(this.data, 'object.spec.clusterAuth.impersonateUser', 'razeedeploy');
-    if (impersonateUser != 'razeedeploy') {
-      krm.addHeader('Impersonate-User', impersonateUser);
-    }
+    let impersonateUser = this.processImpersonation(krm);
 
     let res;
     let reconcile = objectPath.get(child, ['metadata', 'labels', 'deploy.razee.io/Reconcile'], this.reconcileDefault);


### PR DESCRIPTION
Related to this issue: https://github.com/razee-io/razeedeploy-core/issues/189

Admission webhook was created [HERE](https://github.com/razee-io/ImpersonationWebhook) to validate if an authenticated user has impersonation permission. The restriction in the base controllers should be removed since the webhook already handles validation. This means that razee controllers and the webhook must be deployed together.

**Potential breaking changes:**
- Currently, anyone can impersonate others when creating resources in `razeedeploy` namespace. With this change, this will not be allowed if authenticated users are not granted impersonate permission, and the `impersonateUser` field will be set to the authenticated user by the webhook.
- Currently, `impersonateUser` field is set to `razeedeploy` by default if authenticated user tries to impersonate others when creating resources outside of `razeedeploy` namespace. With this change, the default value for `impersonateUser` field will be the authenticated user.