### PR TITLE
feat[Breaking]: Additive merge patch

### DIFF
--- a/lib/BaseController.js
+++ b/lib/BaseController.js
@@ -563,7 +563,7 @@ module.exports = class BaseController {
       }
       let lastApplied = objectPath.get(liveResource, ['metadata', 'annotations', 'deploy.razee.io/last-applied-configuration']);
       if (mode.toLowerCase() === 'additivemergepatch') {
-        // skip the last applied reconcileFields logic and replace our last-applied object with a hint.
+        // skip the last applied reconcileFields logic and replace our last-applied object with a warning.
         objectPath.set(file, ['metadata', 'annotations', 'deploy.razee.io/last-applied-configuration'], additiveMergPatchWarning);
       } else if (!lastApplied || lastApplied == additiveMergPatchWarning) {
         this.log.warn(`${uri}: No deploy.razee.io/last-applied-configuration found`);
@@ -605,7 +605,7 @@ module.exports = class BaseController {
         objectPath.set(file, ['metadata', 'annotations'], {});
       }
       if (mode.toLowerCase() === 'additivemergepatch') {
-        // Set last applied with a hint.
+        // Set last applied with a warning.
         objectPath.set(file, ['metadata', 'annotations', 'deploy.razee.io/last-applied-configuration'], additiveMergPatchWarning);
       } else {
         objectPath.set(file, ['metadata', 'annotations', 'deploy.razee.io/last-applied-configuration'], JSON.stringify(file));

--- a/lib/BaseController.js
+++ b/lib/BaseController.js
@@ -573,7 +573,7 @@ module.exports = class BaseController {
 
         let original = clone(file);
         this.reconcileFields(file, lastApplied);
-        // Ensure annotations is empty object in case reconcileFields set it to null
+        // If reconcileFields set annotations to null, make sure its an empty object instead
         if (objectPath.get(file, ['metadata', 'annotations']) === null) {
           objectPath.set(file, ['metadata', 'annotations'], {});
         }

--- a/lib/BaseController.js
+++ b/lib/BaseController.js
@@ -526,6 +526,7 @@ module.exports = class BaseController {
     let namespace = objectPath.get(file, 'metadata.namespace');
     let uri = krm.uri({ name: objectPath.get(file, 'metadata.name'), namespace: objectPath.get(file, 'metadata.namespace') });
     const mode = objectPath.get(options, 'mode', 'MergePatch');
+    const additiveMergPatchWarning = 'AdditiveMergePatch - Skipping reconcileFields from last-applied.';
     this._logger.debug(`Apply ${uri}`);
     let opt = { simple: false, resolveWithFullResponse: true };
     let liveResource;
@@ -563,8 +564,8 @@ module.exports = class BaseController {
       let lastApplied = objectPath.get(liveResource, ['metadata', 'annotations', 'deploy.razee.io/last-applied-configuration']);
       if (mode.toLowerCase() === 'additivemergepatch') {
         // skip the last applied reconcileFields logic and replace our last-applied object with a hint.
-        objectPath.set(file, ['metadata', 'annotations', 'deploy.razee.io/last-applied-configuration'], 'AdditiveMergePatch - Skipping reconcileFields from last-applied.');
-      } else if (!lastApplied) {
+        objectPath.set(file, ['metadata', 'annotations', 'deploy.razee.io/last-applied-configuration'], additiveMergPatchWarning);
+      } else if (!lastApplied || lastApplied == additiveMergPatchWarning) {
         this.log.warn(`${uri}: No deploy.razee.io/last-applied-configuration found`);
         objectPath.set(file, ['metadata', 'annotations', 'deploy.razee.io/last-applied-configuration'], JSON.stringify(file));
       } else {
@@ -605,7 +606,7 @@ module.exports = class BaseController {
       }
       if (mode.toLowerCase() === 'additivemergepatch') {
         // Set last applied with a hint.
-        objectPath.set(file, ['metadata', 'annotations', 'deploy.razee.io/last-applied-configuration'], 'Skipping reconcileFields - { deploy.razee.io/mode: AdditiveMergePatch }');
+        objectPath.set(file, ['metadata', 'annotations', 'deploy.razee.io/last-applied-configuration'], additiveMergPatchWarning);
       } else {
         objectPath.set(file, ['metadata', 'annotations', 'deploy.razee.io/last-applied-configuration'], JSON.stringify(file));
       }

--- a/lib/BaseController.js
+++ b/lib/BaseController.js
@@ -563,7 +563,7 @@ module.exports = class BaseController {
       let lastApplied = objectPath.get(liveResource, ['metadata', 'annotations', 'deploy.razee.io/last-applied-configuration']);
       if (mode.toLowerCase() === 'additivemergepatch') {
         // skip the last applied reconcileFields logic and replace our last-applied object with a hint.
-        objectPath.set(file, ['metadata', 'annotations', 'deploy.razee.io/last-applied-configuration'], 'Skipping reconcileFields - { deploy.razee.io/mode: AdditiveMergePatch }');
+        objectPath.set(file, ['metadata', 'annotations', 'deploy.razee.io/last-applied-configuration'], 'AdditiveMergePatch - Skipping reconcileFields from last-applied.');
       } else if (!lastApplied) {
         this.log.warn(`${uri}: No deploy.razee.io/last-applied-configuration found`);
         objectPath.set(file, ['metadata', 'annotations', 'deploy.razee.io/last-applied-configuration'], JSON.stringify(file));

--- a/lib/BaseController.js
+++ b/lib/BaseController.js
@@ -73,8 +73,7 @@ module.exports = class BaseController {
   }
   get reconcileDefault() {
     let result;
-    result = objectPath.get(this._data, ['object', 'metadata', 'labels', 'deploy.razee.io/Reconcile']) ||
-      objectPath.get(this._data, ['object', 'metadata', 'labels', 'kapitan.razee.io/Reconcile'], 'true');
+    result = objectPath.get(this._data, ['object', 'metadata', 'labels', 'deploy.razee.io/Reconcile'], 'true');
     return result;
   }
 
@@ -526,6 +525,7 @@ module.exports = class BaseController {
     let name = objectPath.get(file, 'metadata.name');
     let namespace = objectPath.get(file, 'metadata.namespace');
     let uri = krm.uri({ name: objectPath.get(file, 'metadata.name'), namespace: objectPath.get(file, 'metadata.namespace') });
+    const mode = objectPath.get(options, 'mode', 'MergePatch');
     this._logger.debug(`Apply ${uri}`);
     let opt = { simple: false, resolveWithFullResponse: true };
     let liveResource;
@@ -541,8 +541,7 @@ module.exports = class BaseController {
     }
 
     if (liveResource) {
-      let debug = objectPath.get(liveResource, ['metadata', 'labels', 'deploy.razee.io/debug']) ||
-        objectPath.get(liveResource, ['metadata', 'labels', 'kapitan.razee.io/debug'], 'false');
+      let debug = objectPath.get(liveResource, ['metadata', 'labels', 'deploy.razee.io/debug'], 'false');
       if (debug.toLowerCase() === 'true') {
         this.log.warn(`${uri}: Debug enabled on resource: skipping modifying resource - adding annotation deploy.razee.io/pending-configuration.`);
         let patchObject = { metadata: { annotations: { 'deploy.razee.io/pending-configuration': JSON.stringify(file) } } };
@@ -557,9 +556,11 @@ module.exports = class BaseController {
           objectPath.set(file, ['metadata', 'annotations', 'deploy.razee.io/pending-configuration'], null);
         }
       }
-      let lastApplied = objectPath.get(liveResource, ['metadata', 'annotations', 'deploy.razee.io/last-applied-configuration']) ||
-        objectPath.get(liveResource, ['metadata', 'annotations', 'kapitan.razee.io/last-applied-configuration']);
-      if (!lastApplied) {
+      let lastApplied = objectPath.get(liveResource, ['metadata', 'annotations', 'deploy.razee.io/last-applied-configuration']);
+      if (mode.toLowerCase() === 'additivemergepatch') {
+        // skip the last applied reconcileFields logic and remove our last-applied annotation
+        if (lastApplied !== undefined) objectPath.set(file, ['metadata', 'annotations', 'deploy.razee.io/last-applied-configuration'], null);
+      } else if (!lastApplied) {
         this.log.warn(`${uri}: No deploy.razee.io/last-applied-configuration found`);
         objectPath.set(file, ['metadata', 'annotations', 'deploy.razee.io/last-applied-configuration'], JSON.stringify(file));
       } else {
@@ -570,12 +571,11 @@ module.exports = class BaseController {
         if (objectPath.get(file, ['metadata', 'annotations']) === null) {
           objectPath.set(file, ['metadata', 'annotations'], {});
         }
-        objectPath.set(file, ['metadata', 'annotations', 'kapitan.razee.io/last-applied-configuration'], null);
         objectPath.set(file, ['metadata', 'annotations', 'deploy.razee.io/last-applied-configuration'], JSON.stringify(original));
       }
-      if (objectPath.get(options, 'mode', 'MergePatch').toLowerCase() == 'strategicmergepatch') {
+      if (mode.toLowerCase() === 'strategicmergepatch') {
         let res = await krm.strategicMergePatch(name, namespace, file, opt);
-        this._logger.debug(`strategicMergePatch ${res.statusCode} ${uri}`);
+        this._logger.debug(`StrategicMergePatch ${res.statusCode} ${uri}`);
         if (res.statusCode === 415) {
           // let fall through
         } else if (res.statusCode < 200 || res.statusCode >= 300) {
@@ -583,9 +583,9 @@ module.exports = class BaseController {
         } else {
           return { statusCode: res.statusCode, body: res.body };
         }
-      }
+      } // else mode: MergePatch or AdditiveMergePatch
       let res = await krm.mergePatch(name, namespace, file, opt);
-      this._logger.debug(`mergePatch ${res.statusCode} ${uri}`);
+      this._logger.debug(`${mode} ${res.statusCode} ${uri}`);
       if (res.statusCode < 200 || res.statusCode >= 300) {
         return Promise.reject({ statusCode: res.statusCode, body: res.body });
       } else {

--- a/lib/BaseController.js
+++ b/lib/BaseController.js
@@ -558,8 +558,8 @@ module.exports = class BaseController {
       }
       let lastApplied = objectPath.get(liveResource, ['metadata', 'annotations', 'deploy.razee.io/last-applied-configuration']);
       if (mode.toLowerCase() === 'additivemergepatch') {
-        // skip the last applied reconcileFields logic and remove our last-applied annotation
-        if (lastApplied !== undefined) objectPath.set(file, ['metadata', 'annotations', 'deploy.razee.io/last-applied-configuration'], null);
+        // skip the last applied reconcileFields logic and replace our last-applied object with a hint.
+        objectPath.set(file, ['metadata', 'annotations', 'deploy.razee.io/last-applied-configuration'], 'Skipping reconcileFields - { deploy.razee.io/mode: AdditiveMergePatch }');
       } else if (!lastApplied) {
         this.log.warn(`${uri}: No deploy.razee.io/last-applied-configuration found`);
         objectPath.set(file, ['metadata', 'annotations', 'deploy.razee.io/last-applied-configuration'], JSON.stringify(file));
@@ -593,11 +593,17 @@ module.exports = class BaseController {
       }
     } else {
       this._logger.debug(`Post ${uri}`);
+
       // Add last-applied to be used in future apply reconciles
       if (objectPath.get(file, ['metadata', 'annotations']) === null) {
         objectPath.set(file, ['metadata', 'annotations'], {});
       }
-      objectPath.set(file, ['metadata', 'annotations', 'deploy.razee.io/last-applied-configuration'], JSON.stringify(file));
+      if (mode.toLowerCase() === 'additivemergepatch') {
+        // Set last applied with a hint.
+        objectPath.set(file, ['metadata', 'annotations', 'deploy.razee.io/last-applied-configuration'], 'Skipping reconcileFields - { deploy.razee.io/mode: AdditiveMergePatch }');
+      } else {
+        objectPath.set(file, ['metadata', 'annotations', 'deploy.razee.io/last-applied-configuration'], JSON.stringify(file));
+      }
       let post = await krm.post(file, opt);
       if (!(post.statusCode === 200 || post.statusCode === 201 || post.statusCode === 202)) {
         this._logger.debug(`Post ${post.statusCode} ${uri}`);

--- a/lib/BaseController.js
+++ b/lib/BaseController.js
@@ -556,6 +556,10 @@ module.exports = class BaseController {
           objectPath.set(file, ['metadata', 'annotations', 'deploy.razee.io/pending-configuration'], null);
         }
       }
+      // ensure annotations is not null before we start working with it
+      if (objectPath.get(file, ['metadata', 'annotations']) === null) {
+        objectPath.set(file, ['metadata', 'annotations'], {});
+      }
       let lastApplied = objectPath.get(liveResource, ['metadata', 'annotations', 'deploy.razee.io/last-applied-configuration']);
       if (mode.toLowerCase() === 'additivemergepatch') {
         // skip the last applied reconcileFields logic and replace our last-applied object with a hint.
@@ -568,6 +572,7 @@ module.exports = class BaseController {
 
         let original = clone(file);
         this.reconcileFields(file, lastApplied);
+        // Ensure annotations is empty object in case reconcileFields set it to null
         if (objectPath.get(file, ['metadata', 'annotations']) === null) {
           objectPath.set(file, ['metadata', 'annotations'], {});
         }

--- a/lib/CompositeController.js
+++ b/lib/CompositeController.js
@@ -151,6 +151,7 @@ module.exports = class CompositeController extends BaseController {
     let res;
     let reconcile = objectPath.get(child, ['metadata', 'labels', 'deploy.razee.io/Reconcile'], this.reconcileDefault);
     let mode = objectPath.get(child, ['metadata', 'labels', 'deploy.razee.io/mode'], 'Apply');
+    let modeUsed = '';
     if (!objectPath.has(child, ['metadata', 'namespace']) && krm.namespaced) {
       objectPath.set(child, ['metadata', 'namespace'], this.namespace);
       childNamespace = objectPath.get(child, 'metadata.namespace');
@@ -158,22 +159,27 @@ module.exports = class CompositeController extends BaseController {
     childUri = krm.uri({ name: childName, namespace: childNamespace });
     let childUid = objectPath.get(res, 'body.metadata.uid');
 
+
     try {
       switch (mode.toLowerCase()) {
         case 'StrategicMergePatch'.toLowerCase():
+          modeUsed = 'StrategicMergePatch';
           res = await this.apply(krm, child, { mode: 'StrategicMergePatch' });
           break;
         case 'AdditiveMergePatch'.toLowerCase():
+          modeUsed = 'AdditiveMergePatch';
           res = await this.apply(krm, child, { mode: 'AdditiveMergePatch' });
           break;
         case 'EnsureExists'.toLowerCase():
+          modeUsed = 'EnsureExists';
           res = await this.ensureExists(krm, child);
           break;
         default: // Apply - MergePatch
+          modeUsed = 'Apply';
           res = await this.apply(krm, child);
       }
       await this.addChildren({ uid: childUid, selfLink: childUri, 'deploy.razee.io/Reconcile': reconcile, 'Impersonate-User': impersonateUser });
-      this.log.info(`${mode} ${res.statusCode} ${childUri}`);
+      this.log.info(`${modeUsed} ${res.statusCode} ${childUri}`);
     } catch (e) {
       res = e;
     }

--- a/lib/CompositeController.js
+++ b/lib/CompositeController.js
@@ -30,8 +30,7 @@ module.exports = class CompositeController extends BaseController {
     // if cleanup fails, do not return successful response => Promise.reject(err) or throw Error(err)
     let children = objectPath.get(this.data, ['object', 'status', 'children'], {});
     let res = await Promise.all(Object.entries(children).map(async ([selfLink, child]) => {
-      let reconcile = objectPath.get(child, ['deploy.razee.io/Reconcile']) ||
-        objectPath.get(child, ['kapitan.razee.io/Reconcile'], this.reconcileDefault);
+      let reconcile = objectPath.get(child, ['deploy.razee.io/Reconcile'], this.reconcileDefault);
       if (reconcile.toLowerCase() == 'true') {
         try {
           await this._deleteChild(selfLink);
@@ -150,10 +149,8 @@ module.exports = class CompositeController extends BaseController {
     }
 
     let res;
-    let reconcile = objectPath.get(child, ['metadata', 'labels', 'deploy.razee.io/Reconcile']) ||
-      objectPath.get(child, ['metadata', 'labels', 'kapitan.razee.io/Reconcile'], this.reconcileDefault);
-    let mode = objectPath.get(child, ['metadata', 'labels', 'deploy.razee.io/mode']) ||
-      objectPath.get(child, ['metadata', 'labels', 'kapitan.razee.io/mode'], 'Apply');
+    let reconcile = objectPath.get(child, ['metadata', 'labels', 'deploy.razee.io/Reconcile'], this.reconcileDefault);
+    let mode = objectPath.get(child, ['metadata', 'labels', 'deploy.razee.io/mode'], 'Apply');
     if (!objectPath.has(child, ['metadata', 'namespace']) && krm.namespaced) {
       objectPath.set(child, ['metadata', 'namespace'], this.namespace);
       childNamespace = objectPath.get(child, 'metadata.namespace');
@@ -172,7 +169,7 @@ module.exports = class CompositeController extends BaseController {
         case 'EnsureExists'.toLowerCase():
           res = await this.ensureExists(krm, child);
           break;
-        default:
+        default: // Apply - MergePatch
           res = await this.apply(krm, child);
       }
       await this.addChildren({ uid: childUid, selfLink: childUri, 'deploy.razee.io/Reconcile': reconcile, 'Impersonate-User': impersonateUser });
@@ -193,8 +190,7 @@ module.exports = class CompositeController extends BaseController {
 
     let res = await Promise.all(Object.entries(oldChildren).map(async ([selfLink, child]) => {
       const newChild = clone(child);
-      let reconcile = objectPath.get(child, ['deploy.razee.io/Reconcile']) ||
-        objectPath.get(child, ['kapitan.razee.io/Reconcile'], this.reconcileDefault);
+      let reconcile = objectPath.get(child, ['deploy.razee.io/Reconcile'], this.reconcileDefault);
       let exists = objectPath.has(newChildren, [selfLink]);
       if (!exists && reconcile.toLowerCase() == 'true') {
         this.log.info(`${selfLink} no longer applied.. Reconcile ${reconcile.toLowerCase()}.. removing from cluster`);

--- a/lib/CompositeController.js
+++ b/lib/CompositeController.js
@@ -166,6 +166,9 @@ module.exports = class CompositeController extends BaseController {
         case 'StrategicMergePatch'.toLowerCase():
           res = await this.apply(krm, child, { mode: 'StrategicMergePatch' });
           break;
+        case 'AdditiveMergePatch'.toLowerCase():
+          res = await this.apply(krm, child, { mode: 'AdditiveMergePatch' });
+          break;
         case 'EnsureExists'.toLowerCase():
           res = await this.ensureExists(krm, child);
           break;


### PR DESCRIPTION
allow user to define label `deploy.razee.io/mode: AdditiveMergePatch` on a child resource to avoid razeedeploy setting the `last-applied-configuration` annotation on said child resource.

Removes support of old `kapitan` naming for label/annotations.