### PR TITLE
feat: add `MockController`, `MockKubeResourceMeta`

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,10 +24,16 @@ const CompositeController = require('./lib/CompositeController');
 
 const FetchEnvs = require('./lib/FetchEnvs');
 
+const MockController = require('./lib/MockController');
+
+const MockKubeResourceMeta = require('./lib/MockKubeResourceMeta');
+
 module.exports = {
   BaseController,
   BaseDownloadController,
   BaseTemplateController,
   CompositeController,
-  FetchEnvs
+  FetchEnvs,
+  MockController,
+  MockKubeResourceMeta
 };

--- a/lib/BaseTemplateController.js
+++ b/lib/BaseTemplateController.js
@@ -25,14 +25,19 @@ module.exports = class BaseTemplateController extends CompositeController {
     super(params);
   }
 
-  async added() {
-    let fetchEnvs = new FetchEnvs(this);
-    let env = await fetchEnvs.get('spec');
+  concatTemplates() {
     let objTemplates = objectPath.get(this.data, ['object', 'spec', 'templates'], []);
     if (!Array.isArray(objTemplates)) objTemplates = [objTemplates];
     let strTemplates = objectPath.get(this.data, ['object', 'spec', 'strTemplates'], []);
     if (!Array.isArray(strTemplates)) strTemplates = [strTemplates];
     let templates = objTemplates.concat(strTemplates);
+    return templates;
+  }
+
+  async added() {
+    let fetchEnvs = new FetchEnvs(this);
+    let env = await fetchEnvs.get('spec');
+    let templates = this.concatTemplates();
     templates = await this.processTemplate(templates, env);
     if (!Array.isArray(templates) || templates.length == 0) {
       this.updateRazeeLogs('warn', { controller: 'BaseTemplate', message: 'No templates found to apply' });

--- a/lib/MockController.js
+++ b/lib/MockController.js
@@ -1,0 +1,17 @@
+const MockKubeResourceMeta = require('../lib/MockKubeResourceMeta');
+
+module.exports = class MockController {
+  constructor(eventData, kubeData) {
+    this.data = eventData;
+    this.kubeResourceMeta = new MockKubeResourceMeta(
+      this.data.object.apiVersion,
+      this.data.object.kind,
+      kubeData
+    );
+    this.kubeClass = {
+      getKubeResourceMeta: (apiVersion, kind) => {
+        return new MockKubeResourceMeta(apiVersion, kind, kubeData);
+      }
+    };
+  }
+};

--- a/lib/MockKubeResourceMeta.js
+++ b/lib/MockKubeResourceMeta.js
@@ -1,0 +1,60 @@
+module.exports = class MockKubeResourceMeta {
+  constructor(apiVersion, kind, kubeData) {
+    this._apiVersion = ((apiVersion === undefined || apiVersion === '') ? 'deploy.razee.io/v1alpha2' : apiVersion);
+    this._kind = ((kind === undefined || kind === '') ? 'MustacheTemplate' : kind);
+    this.kubeData = kubeData;
+  }
+
+  async request(reqOpt) {
+    const ref = {
+      apiVersion: reqOpt.uri.apiVersion,
+      kind: reqOpt.uri.kind,
+      name: reqOpt.uri.name,
+      namespace: reqOpt.uri.namespace,
+      labelSelector: reqOpt?.qs?.labelSelector
+    };
+
+    const res = await this.kubeGetResource(ref);
+    return res;
+  }
+
+  async get(name, namespace) {
+    const ref = this.uri({ name, namespace });
+    return await this.kubeGetResource(ref);
+  }
+
+  uri(options) {
+    return { ...options, apiVersion: this._apiVersion, kind: this._kind, };
+  }
+
+  async kubeGetResource(ref) {
+    const {
+      name,
+      labelSelector,
+      namespace,
+      kind,
+      apiVersion
+    } = ref;
+    if (!this.kubeData[kind]) {
+      return;
+    }
+
+    let fn = labelSelector ? 'filter' : 'find';
+    let lookup = this.kubeData[kind][fn](obj => {
+      let match = true;
+      match = (obj.apiVersion === apiVersion && match) ? true : false;
+      match = (obj.kind === kind && match) ? true : false;
+      match = ((obj.metadata.name === name || labelSelector !== undefined) && match) ? true : false;
+      match = (obj.metadata.namespace === namespace && match) ? true : false;
+      if (labelSelector) {
+        const objLabels = obj.metadata.labels ?? {};
+        labelSelector.split(',').forEach(label => {
+          let [key, value] = label.split('=');
+          match = (objLabels[key] === value && match) ? true : false;
+        });
+      }
+      return match;
+    });
+    return labelSelector ? { items: lookup } : lookup;
+  }
+};


### PR DESCRIPTION
- these will enable simpler testing here
- it should also enable simpler testing of the `mustachetemplate`
  controller
- this is also ground work for a PR to `mustachetemplate` to add a new
  script it its `bin/` that can render MTPs from files on disk, instead
  of only k8s resources in a live environment, to enable better testing
  of MTPs generally