### PR TITLE
do not limit recursion into lists

### DIFF
--- a/lib/BaseDownloadController.js
+++ b/lib/BaseDownloadController.js
@@ -165,25 +165,21 @@ module.exports = class BaseDownloadController extends CompositeController {
     if (Array.isArray(file)) {
       let error;
       let res = await Promise.all(file.map(async f => {
-        return this.limit(async () => {
-          try {
-            return await this._decomposeFile(f);
-          } catch (e) {
-            error = error || e;
-          }
-        });
+        try {
+          return await this._decomposeFile(f);
+        } catch (e) {
+          error = error || e;
+        }
       }));
       return error ? Promise.reject(error) : res;
     } else if (kind.toLowerCase() == 'list' && Array.isArray(items)) {
       let error;
       let res = await Promise.all(items.map(async f => {
-        return this.limit(async () => {
-          try {
-            return await this._decomposeFile(f);
-          } catch (e) {
-            error = error || e;
-          }
-        });
+        try {
+          return await this._decomposeFile(f);
+        } catch (e) {
+          error = error || e;
+        }
       }));
       return error ? Promise.reject(error) : res;
     } else if (file) {
@@ -259,7 +255,10 @@ module.exports = class BaseDownloadController extends CompositeController {
   }
 
   async _saveChild(child) {
-    let res = await this.applyChild(child);
+    let res = await this.limit(async () => {
+      return await this.applyChild(child);
+    });
+
     if (!res.statusCode || res.statusCode < 200 || res.statusCode >= 300) {
       return Promise.reject(res);
     }


### PR DESCRIPTION
Bugfix: prevent processing that never completes when resources to be applied contains five or more Lists.

Bug originally introduced in https://github.com/razee-io/razeedeploy-core/pull/344