### PR TITLE
Ensure parent cleanup and ability to become parent of an orphan

### DIFF
--- a/lib/BaseController.js
+++ b/lib/BaseController.js
@@ -600,7 +600,7 @@ module.exports = class BaseController {
       if (currentParent && (currentParent != this.selfLink)) {
         // Check to see if the current parent still exists.  If it doesnt, it can be taken over.
         try {
-          let getParent = await this.kubeResourceMeta.request({ uri: currentParent, json: true });
+          await this.kubeResourceMeta.request({ uri: currentParent, json: true });
           // Current parent still exists, abort with `Multiple Parents` response
           return { statusCode: 200, body: `Multiple Parents` };
         }

--- a/lib/BaseController.js
+++ b/lib/BaseController.js
@@ -598,14 +598,20 @@ module.exports = class BaseController {
     if (liveResource) {
       let currentParent = objectPath.get(liveResource, ['metadata', 'annotations', 'deploy.razee.io.parent']);
       if (currentParent && (currentParent != this.selfLink)) {
-        // Check to see if the current parent still exists.  If it doesn't, it can be taken over.
-        let getParent = await this.kubeResourceMeta.request({ uri: currentParent, json: true });
-        if( getParent.statusCode === 404 ) {
-          // Current parent is gone, continue and assume parent role
-          this.log.info(`parent ${currentParent} no longer exists, asserting ownership for new parent ${this.selfLink}`);
-        } else {
-          // Current parent still exists, abort with 'Multiple Parents' response
-          return { statusCode: 200, body: 'Multiple Parents' };
+        // Check to see if the current parent still exists.  If it doesnt, it can be taken over.
+        try {
+          let getParent = await this.kubeResourceMeta.request({ uri: currentParent, json: true });
+          // Current parent still exists, abort with `Multiple Parents` response
+          return { statusCode: 200, body: `Multiple Parents` };
+        }
+        catch( e ) {
+          if( e.statusCode === 404 ) {
+            // Current parent is gone, continue and assume parent role
+            this.log.info( `parent ${currentParent} no longer exists, asserting ownership for new parent ${this.selfLink}` );
+          }
+          else {
+            throw e;
+          }
         }
       }
 

--- a/lib/BaseController.js
+++ b/lib/BaseController.js
@@ -602,7 +602,7 @@ module.exports = class BaseController {
         try {
           await this.kubeResourceMeta.request({ uri: currentParent, json: true });
           // Current parent still exists, abort with `Multiple Parents` response
-          return { statusCode: 200, body: `Multiple Parents` };
+          return { statusCode: 200, body: 'Multiple Parents' };
         }
         catch( e ) {
           if( e.statusCode === 404 ) {

--- a/lib/BaseController.js
+++ b/lib/BaseController.js
@@ -598,8 +598,17 @@ module.exports = class BaseController {
     if (liveResource) {
       let currentParent = objectPath.get(liveResource, ['metadata', 'annotations', 'deploy.razee.io.parent']);
       if (currentParent && (currentParent != this.selfLink)) {
-        return { statusCode: 200, body: 'Multiple Parents' };
+        // Check to see if the current parent still exists.  If it doesn't, it can be taken over.
+        let getParent = await this.kubeResourceMeta.request({ uri: currentParent, json: true });
+        if( getParent.statusCode === 404 ) {
+          // Current parent is gone, continue and assume parent role
+          this.log.info(`parent ${currentParent} no longer exists, asserting ownership for new parent ${this.selfLink}`);
+        } else {
+          // Current parent still exists, abort with 'Multiple Parents' response
+          return { statusCode: 200, body: 'Multiple Parents' };
+        }
       }
+
       let debug = objectPath.get(liveResource, ['metadata', 'labels', 'deploy.razee.io/debug'], 'false');
       if (debug.toLowerCase() === 'true') {
         this.log.warn(`${uri}: Debug enabled on resource: skipping modifying resource - adding annotation deploy.razee.io/pending-configuration.`);

--- a/lib/CompositeController.js
+++ b/lib/CompositeController.js
@@ -37,21 +37,28 @@ module.exports = class CompositeController extends BaseController {
     // if cleanup fails, do not return successful response => Promise.reject(err) or throw Error(err)
     let children = objectPath.get(this.data, ['object', 'status', 'children'], {});
     let res = await Promise.all(Object.entries(children).map(async ([selfLink, child]) => {
-      let reconcile = objectPath.get(child, ['deploy.razee.io/Reconcile'], this.reconcileDefault);
-      if (reconcile.toLowerCase() == 'true') {
-        try {
+      try {
+        let reconcile = objectPath.get(child, ['deploy.razee.io/Reconcile'], this.reconcileDefault);
+        if (reconcile.toLowerCase() == 'true') {
+          // If child is to be Reconciled, delete it
+          this.log.info(`finalizer: ${selfLink} no longer applied.. Reconcile ${reconcile.toLowerCase()}.. removing from cluster`);
           await this._deleteChild(selfLink);
-          let res = await this.patchSelf({
-            status: {
-              children: {
-                [selfLink]: null
-              }
-            }
-          }, { status: true });
-          objectPath.set(this.data, 'object', res);
-        } catch (e) {
-          return Promise.reject({ selfLink: selfLink, action: 'delete', state: 'fail', error: e.message || e });
         }
+        else {
+          // If child is NOT to be Reconciled, remove the parent reference
+          this.log.info(`finalizer: ${selfLink} no longer applied.. Reconcile ${reconcile.toLowerCase()}.. leaving on cluster`);
+          await this._patchChild(selfLink);
+        }
+        let res = await this.patchSelf({
+          status: {
+            children: {
+              [selfLink]: null
+            }
+          }
+        }, { status: true });
+        objectPath.set(this.data, 'object', res);
+      } catch (e) {
+        return Promise.reject({ selfLink: selfLink, action: 'delete', state: 'fail', error: e.message || e });
       }
     }));
     return res;


### PR DESCRIPTION
https://github.com/razee-io/RemoteResource/issues/399

This PR addresses a gap from https://github.com/razee-io/razeedeploy-core/pull/360, where `Reconcile: false` children left on a cluster after parent RR deletion (orphans) would keep a reference to their prior parent and could not be modified by future RemoteResources.