### PR TITLE
Optimized resource retrieval for FetchEnvs

### DIFF
--- a/lib/FetchEnvs.js
+++ b/lib/FetchEnvs.js
@@ -94,6 +94,7 @@ module.exports = class FetchEnvs {
   }
 
   // This function needs to be called any time a watch on a potentially cached item is triggered by create/update/delete, e.g. in the ReferencedResourceManager
+  // If it is not, the changed resource may still be served from cache until the TTL expires
   static deleteFromGlobalCache(apiVersion, kind, namespace, name) {
     const cacheKey = [apiVersion, kind, namespace, name].join('/');
     // When deleting a key, delete it for all users

--- a/lib/FetchEnvs.js
+++ b/lib/FetchEnvs.js
@@ -103,7 +103,7 @@ module.exports = class FetchEnvs {
         globalResourceCache.delete(`${cacheUser}/${cacheKey}`);
       }
     }
-    log.info( `FetchEnvs cache deleted for '*/${key}'` );
+    log.info( `FetchEnvs cache deleted for '*/${cacheKey}'` );
   }
 
   #secretMapRef(conf) {

--- a/lib/FetchEnvs.js
+++ b/lib/FetchEnvs.js
@@ -108,7 +108,9 @@ module.exports = class FetchEnvs {
 
     if (!data) {
       console.log(kubeError);
-      const msg = `failed to get envFrom: ${JSON.stringify(conf)}. ${kubeError.message || kubeError}`;
+      // eslint-disable-next-line no-unused-vars
+      const {resourceCache: _, ...confWithoutCache} = conf;
+      const msg = `failed to get envFrom: ${JSON.stringify(confWithoutCache)}. ${kubeError.message || kubeError}`;
       const err = new Error(msg);
       err.code = kubeError.statusCode;
       if (!optional || (err.code != 404 && kubeError != ERR_NODATA)) throw err;
@@ -151,14 +153,14 @@ module.exports = class FetchEnvs {
       apiVersion = 'v1'
     } = ref;
 
+    const matchLabelsQS = labelSelectors(matchLabels);
+
     const cacheKey = this.#getResourceCacheKey(apiVersion, kind, namespace, name, matchLabels);
     if( conf?.resourceCache?.[cacheKey] ) {
       response = conf.resourceCache[cacheKey];
     }
     else {
       const krm = await this.kubeClass.getKubeResourceMeta(apiVersion, kind, 'update');
-
-      const matchLabelsQS = labelSelectors(matchLabels);
 
       if (krm) {
         try {
@@ -180,11 +182,11 @@ module.exports = class FetchEnvs {
     // Reduce to a single value via the specified strategy ('merge' combines objects, otherwise a single value is picked).
     if (typeof matchLabelsQS === OBJECT) {
       // Cache each retrieved resource
-      if( conf.resourceCache ) {
+      if( conf.resourceCache && response?.items ) {
         response.items.forEach(function (item) {
           const cacheKey = this.#getResourceCacheKey(item.apiVersion, item.kind, item.metadata.namespace, item.metadata.name);
           if( !conf.resourceCache[cacheKey] ) conf.resourceCache[cacheKey] = item;
-        });
+        }, this);
       }
       const output = response?.items.reduce(
         reduceItemList(ref, strategy, decode),
@@ -197,7 +199,9 @@ module.exports = class FetchEnvs {
 
     if (value === undefined) {
       if (defaultValue === undefined || (kubeError.statusCode != 404 && kubeError != ERR_NODATA)) {
-        const msg = `failed to get env: ${JSON.stringify(conf)}. ${kubeError.message || kubeError}`;
+        // eslint-disable-next-line no-unused-vars
+        const {resourceCache: _, ...confWithoutCache} = conf;
+        const msg = `failed to get env: ${JSON.stringify(confWithoutCache)}. ${kubeError.message || kubeError}`;
         const err = new Error(msg);
         err.code = kubeError.statusCode;
         if (!optional || (err.code != 404 && kubeError != ERR_NODATA)) throw err;
@@ -206,7 +210,9 @@ module.exports = class FetchEnvs {
       } else {
         value = defaultValue;
         decode = false;
-        const msg = `failed to get env: ${JSON.stringify(conf)}. Using default value: ${defaultValue}`;
+        // eslint-disable-next-line no-unused-vars
+        const {resourceCache: _, ...confWithoutCache} = conf;
+        const msg = `failed to get env: ${JSON.stringify(confWithoutCache)}. Using default value: ${defaultValue}`;
 
         log.warn(msg);
         this.updateRazeeLogs('warn', { controller: 'FetchEnvs', message: msg });
@@ -228,8 +234,8 @@ module.exports = class FetchEnvs {
 
   @return Array of objects like ``[ { configMapRef: { ... }, data: { key1: val1, key2: val2, ... } }, ... ]``
   */
-  processEnvFrom(envFrom, resourceCache) {
-    return Promise.all(envFrom.map((element) => {
+  async processEnvFrom(envFrom, resourceCache) {
+    const retVal = await Promise.all(envFrom.map((element) => {
       const { configMapRef, secretMapRef, genericMapRef } = element;
 
       if (!configMapRef && !secretMapRef && !genericMapRef) {
@@ -240,6 +246,7 @@ module.exports = class FetchEnvs {
       if (secretMapRef) return this.#secretMapRef({ ...element, resourceCache });
       return this.#genericMapRef({ ...element, resourceCache });
     }));
+    return( retVal );
   }
 
   /*
@@ -258,21 +265,24 @@ module.exports = class FetchEnvs {
   async #processEnv(envs, resourceCache) {
     const retVal = [];
     for( const env of envs ) {
-      if (env.value) return env;
-
-      const valueFrom = env.valueFrom || {};
-      const { genericKeyRef, configMapKeyRef, secretKeyRef } = valueFrom;
-
-      if (!genericKeyRef && !configMapKeyRef && !secretKeyRef) {
-        throw new Error(`oneOf genericKeyRef, configMapKeyRef, secretKeyRef must be defined. Got: ${JSON.stringify(env)}`);
+      if (env.value) {
+        retVal.push( env );
       }
+      else {
+        const valueFrom = env.valueFrom || {};
+        const { genericKeyRef, configMapKeyRef, secretKeyRef } = valueFrom;
 
-      let value;
-      if (secretKeyRef) value = await this.#secretKeyRef({ ...env, resourceCache });
-      if (configMapKeyRef) value = await this.#configMapKeyRef({ ...env, resourceCache });
-      if (genericKeyRef) value = await this.#genericKeyRef({ ...env, resourceCache });
+        if (!genericKeyRef && !configMapKeyRef && !secretKeyRef) {
+          throw new Error(`oneOf genericKeyRef, configMapKeyRef, secretKeyRef must be defined. Got: ${JSON.stringify(env)}`);
+        }
 
-      retVal.push( { ...env, value } );
+        let value;
+        if (secretKeyRef) value = await this.#secretKeyRef({ ...env, resourceCache });
+        if (configMapKeyRef) value = await this.#configMapKeyRef({ ...env, resourceCache });
+        if (genericKeyRef) value = await this.#genericKeyRef({ ...env, resourceCache });
+
+        retVal.push( { ...env, value } );
+      }
     }
     return retVal;
   }

--- a/lib/FetchEnvs.js
+++ b/lib/FetchEnvs.js
@@ -93,17 +93,34 @@ module.exports = class FetchEnvs {
     }
   }
 
-  // This function needs to be called any time a watch on a potentially cached item is triggered by create/update/delete, e.g. in the ReferencedResourceManager
-  // If it is not, the changed resource may still be served from cache until the TTL expires
-  static deleteFromGlobalCache(apiVersion, kind, namespace, name) {
-    const cacheKey = [apiVersion, kind, namespace, name].join('/');
+  // This function needs to be called any time a watch on a potentially cached item is triggered by creation/update/poll, e.g. in the ReferencedResourceManager
+  // If it is not, the old resource may still be served from cache until the TTL expires
+  static updateInGlobalCache(resource) {
+    const cacheKey = [resource?.apiVersion, resource?.kind, resource?.metadata?.namespace, resource?.metadata?.name].join('/');
+    let updated = false;
+    // When updating a key, updating it for all users
+    for( const cacheUser of globalResourceCacheUsers ) {
+      if( globalResourceCache.has(`${cacheUser}/${cacheKey}`) ) {
+        globalResourceCache.set(`${cacheUser}/${cacheKey}`, resource);
+        updated = true;
+      }
+    }
+    if( updated ) log.info( `FetchEnvs cache updated for "*/${cacheKey}"` );
+  }
+
+  // This function needs to be called any time a watch on a potentially cached item is triggered by deletion, e.g. in the ReferencedResourceManager
+  // If it is not, the deleted resource may still be served from cache until the TTL expires
+  static deleteFromGlobalCache(resource) {
+    const cacheKey = [resource?.apiVersion, resource?.kind, resource?.metadata?.namespace, resource?.metadata?.name].join('/');
+    let deleted = false;
     // When deleting a key, delete it for all users
     for( const cacheUser of globalResourceCacheUsers ) {
       if( globalResourceCache.has(`${cacheUser}/${cacheKey}`) ) {
         globalResourceCache.delete(`${cacheUser}/${cacheKey}`);
+        deleted = true;
       }
     }
-    log.info( `FetchEnvs cache deleted for '*/${cacheKey}'` );
+    if( deleted ) log.info( `FetchEnvs cache deleted for "*/${cacheKey}"` );
   }
 
   #secretMapRef(conf) {

--- a/lib/FetchEnvs.js
+++ b/lib/FetchEnvs.js
@@ -27,6 +27,17 @@ const KIND_MAP = new Map([
   ['configMapKeyRef', 'ConfigMap']
 ]);
 
+const LRU = require('lru-cache');
+const LruOptions = {
+  maxSize: 100000, // the max cache size
+  sizeCalculation: (r) => { return( JSON.stringify(r).length ); }, // how to determine the size of a resource added to the cache
+  ttl: 1000 * 60 * 3,  // max time to cache (LRU does not directly enforce, but maxSize will eventually push them out)
+  updateAgeOnGet: false,  // Don't update ttl when an item is retrieved from cache
+  updateAgeOnHas: false,  // Don't update ttl when an item is checked in cache
+};
+const globalResourceCache = new LRU( LruOptions );
+const globalResourceCacheUsers = new Set();
+
 module.exports = class FetchEnvs {
 
   get [Symbol.toStringTag]() {
@@ -45,6 +56,53 @@ module.exports = class FetchEnvs {
     this.updateRazeeLogs = controllerObject.updateRazeeLogs ?
       ((logLevel, log) => { controllerObject.updateRazeeLogs(logLevel, log); }) :
       (() => { log.debug('\'updateRazeeLogs()\' not passed to fetchEnvs. will not update razeeLogs on failure to fetch envs'); });
+
+    const user = this.data?.object?.spec?.clusterAuth?.impersonateUser;
+    if( process.env.INSTANCE_FETCHENVS_CACHE_ONLY ) {
+      // Using `user` is not technically necessary for an instance-specific cache, but used for consistency
+      log.info( 'FetchEnvs.constructor using instance-specific resource cache' );
+      this.instanceCache = {};
+      this.resourceCache = {
+        has: (key) => {
+          const hit = Object.prototype.hasOwnProperty.call(this.instanceCache, `${user}/${key}`);
+          log.info( `FetchEnvs cache ${hit?'HIT':'MISS'}: '${user}/${key}'` );
+          return hit;
+        },
+        set: (key, value) => { this.instanceCache[`${user}/${key}`] = value; },
+        get: (key) => { return this.instanceCache[`${user}/${key}`]; },
+      };
+    }
+    else {
+      log.info( `FetchEnvs.constructor using global resource cache, ${globalResourceCache.size} resources currently cached (may be TTL expired)` );
+      this.resourceCache = {
+        has: (key) => {
+          const hit = globalResourceCache.has(`${user}/${key}`);
+          log.info( `FetchEnvs cache ${hit?'HIT':'MISS'}: '${user}/${key}'` );
+          return hit;
+        },
+        set: (key, value) => {
+          // When setting a key, keep track of users to allow later deletion
+          globalResourceCacheUsers.add( user );
+          globalResourceCache.set(`${user}/${key}`, value);
+          log.info( `FetchEnvs cached '${user}/${key}'` );
+        },
+        get: (key) => {
+          return globalResourceCache.get(`${user}/${key}`);
+        },
+      };
+    }
+  }
+
+  // This function needs to be called any time a watch on a potentially cached item is triggered by create/update/delete, e.g. in the ReferencedResourceManager
+  static deleteFromGlobalCache(apiVersion, kind, namespace, name) {
+    const cacheKey = [apiVersion, kind, namespace, name].join('/');
+    // When deleting a key, delete it for all users
+    for( const cacheUser of globalResourceCacheUsers ) {
+      if( globalResourceCache.has(`${cacheUser}/${cacheKey}`) ) {
+        globalResourceCache.delete(`${cacheUser}/${cacheKey}`);
+      }
+    }
+    log.info( `FetchEnvs cache deleted for '*/${key}'` );
   }
 
   #secretMapRef(conf) {
@@ -61,10 +119,6 @@ module.exports = class FetchEnvs {
 
   #configMapKeyRef(conf) {
     return this.#genericKeyRef(conf, 'configMapKeyRef');
-  }
-
-  #getResourceCacheKey(apiVersion, kind, namespace, name, matchLabels) {
-    return `${apiVersion}/${kind}/${namespace}/${name}/${JSON.stringify(matchLabels)}`;
   }
 
   /*
@@ -87,9 +141,9 @@ module.exports = class FetchEnvs {
       name
     } = ref;
 
-    const cacheKey = this.#getResourceCacheKey(apiVersion, kind, namespace, name);
-    if( conf?.resourceCache?.[cacheKey] ) {
-      resource = conf.resourceCache[cacheKey];
+    const cacheKey = [apiVersion, kind, namespace, name].join('/');
+    if( this.resourceCache.has( cacheKey ) ) {
+      resource = this.resourceCache.get( cacheKey );
     }
     else {
       const krm = await this.kubeClass.getKubeResourceMeta(apiVersion, kind, 'update');
@@ -97,7 +151,9 @@ module.exports = class FetchEnvs {
       if (krm) {
         try {
           resource = await krm.get(name, namespace);
-          if( conf.resourceCache ) conf.resourceCache[cacheKey] = resource; // Cache this resource
+          if( resource ) {
+            this.resourceCache.set( cacheKey, resource ); // Cache this resource
+          }
         } catch (error) {
           kubeError = error;
         }
@@ -108,9 +164,7 @@ module.exports = class FetchEnvs {
 
     if (!data) {
       console.log(kubeError);
-      // eslint-disable-next-line no-unused-vars
-      const {resourceCache: _, ...confWithoutCache} = conf;
-      const msg = `failed to get envFrom: ${JSON.stringify(confWithoutCache)}. ${kubeError.message || kubeError}`;
+      const msg = `failed to get envFrom: ${JSON.stringify(conf)}. ${kubeError.message || kubeError}`;
       const err = new Error(msg);
       err.code = kubeError.statusCode;
       if (!optional || (err.code != 404 && kubeError != ERR_NODATA)) throw err;
@@ -155,9 +209,10 @@ module.exports = class FetchEnvs {
 
     const matchLabelsQS = labelSelectors(matchLabels);
 
-    const cacheKey = this.#getResourceCacheKey(apiVersion, kind, namespace, name, matchLabels);
-    if( conf?.resourceCache?.[cacheKey] ) {
-      response = conf.resourceCache[cacheKey];
+    const cacheKey = [apiVersion, kind, namespace, name].join('/');
+    // Note: Using `matchLabels` will always result in a kube api call, label-based queries cannot use the resourceCache
+    if( !matchLabelsQS && this.resourceCache.has(cacheKey) ) {
+      response = this.resourceCache.get(cacheKey);
     }
     else {
       const krm = await this.kubeClass.getKubeResourceMeta(apiVersion, kind, 'update');
@@ -169,7 +224,10 @@ module.exports = class FetchEnvs {
             json: true,
             qs: matchLabelsQS
           });
-          if( conf.resourceCache ) conf.resourceCache[cacheKey] = response; // Cache this resource (or set of resources, if using matchLabels)
+          // Note: cache here only if getting a single resource
+          if( response?.data && !response?.items ) {
+            this.resourceCache.set(cacheKey, response);
+          }
         } catch (error) {
           kubeError = error;
         }
@@ -181,11 +239,11 @@ module.exports = class FetchEnvs {
     // If matching by labels, there can be multiple matching resources.
     // Reduce to a single value via the specified strategy ('merge' combines objects, otherwise a single value is picked).
     if (typeof matchLabelsQS === OBJECT) {
-      // Cache each retrieved resource
-      if( conf.resourceCache && response?.items ) {
+      // Cache here if there are multiple retrieved resources
+      if( response?.items ) {
         response.items.forEach(function (item) {
-          const cacheKey = this.#getResourceCacheKey(item.apiVersion, item.kind, item.metadata.namespace, item.metadata.name);
-          if( !conf.resourceCache[cacheKey] ) conf.resourceCache[cacheKey] = item;
+          const cacheKey = [item.apiVersion, item.kind, item.metadata.namespace, item.metadata.name].join('/');
+          this.resourceCache.set(cacheKey, item);
         }, this);
       }
       const output = response?.items.reduce(
@@ -199,9 +257,7 @@ module.exports = class FetchEnvs {
 
     if (value === undefined) {
       if (defaultValue === undefined || (kubeError.statusCode != 404 && kubeError != ERR_NODATA)) {
-        // eslint-disable-next-line no-unused-vars
-        const {resourceCache: _, ...confWithoutCache} = conf;
-        const msg = `failed to get env: ${JSON.stringify(confWithoutCache)}. ${kubeError.message || kubeError}`;
+        const msg = `failed to get env: ${JSON.stringify(conf)}. ${kubeError.message || kubeError}`;
         const err = new Error(msg);
         err.code = kubeError.statusCode;
         if (!optional || (err.code != 404 && kubeError != ERR_NODATA)) throw err;
@@ -210,9 +266,7 @@ module.exports = class FetchEnvs {
       } else {
         value = defaultValue;
         decode = false;
-        // eslint-disable-next-line no-unused-vars
-        const {resourceCache: _, ...confWithoutCache} = conf;
-        const msg = `failed to get env: ${JSON.stringify(confWithoutCache)}. Using default value: ${defaultValue}`;
+        const msg = `failed to get env: ${JSON.stringify(conf)}. Using default value: ${defaultValue}`;
 
         log.warn(msg);
         this.updateRazeeLogs('warn', { controller: 'FetchEnvs', message: msg });
@@ -230,11 +284,10 @@ module.exports = class FetchEnvs {
   Retrieve all values from specified kube resources.
 
   @param[I] envs Array of objects like `[ { configMapRef: { ... }, ... } ]`
-  @param[I] resourceCache A map of selfLink to previously retrieved resource object, to eliminate need to repeatedly retrieve the same resource
 
   @return Array of objects like ``[ { configMapRef: { ... }, data: { key1: val1, key2: val2, ... } }, ... ]``
   */
-  async processEnvFrom(envFrom, resourceCache) {
+  async processEnvFrom(envFrom) {
     const retVal = await Promise.all(envFrom.map((element) => {
       const { configMapRef, secretMapRef, genericMapRef } = element;
 
@@ -242,9 +295,9 @@ module.exports = class FetchEnvs {
         throw new Error(`oneOf configMapRef, secretMapRef, genericMapRef must be defined. Got: ${JSON.stringify(element)}`);
       }
 
-      if (configMapRef) return this.#configMapRef({ ...element, resourceCache });
-      if (secretMapRef) return this.#secretMapRef({ ...element, resourceCache });
-      return this.#genericMapRef({ ...element, resourceCache });
+      if (configMapRef) return this.#configMapRef(element);
+      if (secretMapRef) return this.#secretMapRef(element);
+      return this.#genericMapRef(element);
     }));
     return( retVal );
   }
@@ -258,11 +311,10 @@ module.exports = class FetchEnvs {
   as if from Promise.all.
 
   @param[I] envs Array of objects like `[ { configMapKeyRef: { ... }, ... } ]`
-  @param[I] resourceCache A map of selfLink to previously retrieved resource object, to eliminate need to repeatedly retrieve the same resource
 
   @return Array of objects like `[ { configMapKeyRef: { ... }, value: asdf }, ... ]`
   */
-  async #processEnv(envs, resourceCache) {
+  async #processEnv(envs) {
     const retVal = [];
     for( const env of envs ) {
       if (env.value) {
@@ -277,9 +329,9 @@ module.exports = class FetchEnvs {
         }
 
         let value;
-        if (secretKeyRef) value = await this.#secretKeyRef({ ...env, resourceCache });
-        if (configMapKeyRef) value = await this.#configMapKeyRef({ ...env, resourceCache });
-        if (genericKeyRef) value = await this.#genericKeyRef({ ...env, resourceCache });
+        if (secretKeyRef) value = await this.#secretKeyRef(env);
+        if (configMapKeyRef) value = await this.#configMapKeyRef(env);
+        if (genericKeyRef) value = await this.#genericKeyRef(env);
 
         retVal.push( { ...env, value } );
       }
@@ -304,7 +356,6 @@ module.exports = class FetchEnvs {
   @return A map of keys to values
   */
   async get(path = 'spec') {
-    const resourceCache = {};
     let result = {};
     // removes any number of '.' at the start and end of the path, and
     // removes the '.env' or '.envFrom' if the paths ends in either
@@ -312,7 +363,7 @@ module.exports = class FetchEnvs {
 
     let envFrom = objectPath.get(this.data, `object.${path}.envFrom`, []);
 
-    envFrom = await this.processEnvFrom(envFrom, resourceCache);
+    envFrom = await this.processEnvFrom(envFrom);
     for (const env of envFrom) {
       const data = env?.data ?? {};
       result = { ...result, ...data };
@@ -320,7 +371,7 @@ module.exports = class FetchEnvs {
 
     let env = objectPath.get(this.data, `object.${path}.env`, []);
 
-    env = await this.#processEnv(env, resourceCache);
+    env = await this.#processEnv(env);
     return (env).reduce(reduceEnv, result);
   }
 

--- a/lib/FetchEnvs.js
+++ b/lib/FetchEnvs.js
@@ -63,6 +63,17 @@ module.exports = class FetchEnvs {
     return this.#genericKeyRef(conf, 'configMapKeyRef');
   }
 
+  #getResourceCacheKey(apiVersion, kind, namespace, name, matchLabels) {
+    return `${apiVersion}/${kind}/${namespace}/${name}/${JSON.stringify(matchLabels)}`;
+  }
+
+  /*
+  @param[I] conf An object like `{ configMapRef: { name: 'asdf', namespace: 'asdf' } }`.
+  @param[I] valueFrom The name of the conf attribute containing resource details, e.g. `configMapRef`.
+  @param[I] decode A boolean indicating whether to base64 decode the values retrieved, e.g. from Secrets
+
+  @return An object like { configMapRef: { name: 'asdf', namespace: 'asdf' }, data: { key1: val1, ... } }
+  */
   async #genericMapRef(conf, valueFrom = 'genericMapRef', decode = false) {
     let resource;
     let kubeError = ERR_NODATA;
@@ -76,13 +87,20 @@ module.exports = class FetchEnvs {
       name
     } = ref;
 
-    const krm = await this.kubeClass.getKubeResourceMeta(apiVersion, kind, 'update');
+    const cacheKey = this.#getResourceCacheKey(apiVersion, kind, namespace, name);
+    if( conf?.resourceCache?.[cacheKey] ) {
+      resource = conf.resourceCache[cacheKey];
+    }
+    else {
+      const krm = await this.kubeClass.getKubeResourceMeta(apiVersion, kind, 'update');
 
-    if (krm) {
-      try {
-        resource = await krm.get(name, namespace);
-      } catch (error) {
-        kubeError = error;
+      if (krm) {
+        try {
+          resource = await krm.get(name, namespace);
+          if( conf.resourceCache ) conf.resourceCache[cacheKey] = resource; // Cache this resource
+        } catch (error) {
+          kubeError = error;
+        }
       }
     }
 
@@ -108,6 +126,14 @@ module.exports = class FetchEnvs {
     return { ...conf, data };
   }
 
+  /*
+  @param[I] conf An object like `{ default: '{default:true}', overrideStrategy: 'merge', configMapRef: { name: 'asdf', namespace: 'asdf', key: 'asdf', type: 'json' } }`
+  - name, namespace, and matchLabels identify the resource
+  - key identifies the data inside the resource
+  - type identifies how to typecast the value
+
+  @return The discovered value
+  */
   async #genericKeyRef(conf, valueFrom = 'genericKeyRef', decode = false) {
     let response;
     let kubeError = ERR_NODATA;
@@ -125,36 +151,48 @@ module.exports = class FetchEnvs {
       apiVersion = 'v1'
     } = ref;
 
-    const krm = await this.kubeClass.getKubeResourceMeta(
-      apiVersion,
-      kind,
-      'update'
-    );
+    const cacheKey = this.#getResourceCacheKey(apiVersion, kind, namespace, name, matchLabels);
+    if( conf?.resourceCache?.[cacheKey] ) {
+      response = conf.resourceCache[cacheKey];
+    }
+    else {
+      const krm = await this.kubeClass.getKubeResourceMeta(apiVersion, kind, 'update');
 
-    const matchLabelsQS = labelSelectors(matchLabels);
+      const matchLabelsQS = labelSelectors(matchLabels);
 
-    if (krm) {
-      try {
-        response = await this.api({
-          uri: krm.uri({ namespace, name }),
-          json: true,
-          qs: matchLabelsQS
-        });
-      } catch (error) {
-        kubeError = error;
+      if (krm) {
+        try {
+          response = await this.api({
+            uri: krm.uri({ namespace, name }),
+            json: true,
+            qs: matchLabelsQS
+          });
+          if( conf.resourceCache ) conf.resourceCache[cacheKey] = response; // Cache this resource (or set of resources, if using matchLabels)
+        } catch (error) {
+          kubeError = error;
+        }
       }
     }
 
     let value = response?.data?.[key];
 
+    // If matching by labels, there can be multiple matching resources.
+    // Reduce to a single value via the specified strategy ('merge' combines objects, otherwise a single value is picked).
     if (typeof matchLabelsQS === OBJECT) {
+      // Cache each retrieved resource
+      if( conf.resourceCache ) {
+        response.items.forEach(function (item) {
+          const cacheKey = this.#getResourceCacheKey(item.apiVersion, item.kind, item.metadata.namespace, item.metadata.name);
+          if( !conf.resourceCache[cacheKey] ) conf.resourceCache[cacheKey] = item;
+        });
+      }
       const output = response?.items.reduce(
         reduceItemList(ref, strategy, decode),
         Object.create(null)
       );
 
       value = output?.[key];
-      decode = false;
+      decode = false; // 'decode' was used in the reduceItemList, set to false to avoid double-decoding.
     }
 
     if (value === undefined) {
@@ -182,8 +220,15 @@ module.exports = class FetchEnvs {
     return typeCast(name, value, type);
   }
 
+  /*
+  Retrieve all values from specified kube resources.
 
-  processEnvFrom(envFrom) {
+  @param[I] envs Array of objects like `[ { configMapRef: { ... }, ... } ]`
+  @param[I] resourceCache A map of selfLink to previously retrieved resource object, to eliminate need to repeatedly retrieve the same resource
+
+  @return Array of objects like ``[ { configMapRef: { ... }, data: { key1: val1, key2: val2, ... } }, ... ]``
+  */
+  processEnvFrom(envFrom, resourceCache) {
     return Promise.all(envFrom.map((element) => {
       const { configMapRef, secretMapRef, genericMapRef } = element;
 
@@ -191,15 +236,30 @@ module.exports = class FetchEnvs {
         throw new Error(`oneOf configMapRef, secretMapRef, genericMapRef must be defined. Got: ${JSON.stringify(element)}`);
       }
 
-      if (configMapRef) return this.#configMapRef(element);
-      if (secretMapRef) return this.#secretMapRef(element);
-      return this.#genericMapRef(element);
+      if (configMapRef) return this.#configMapRef({ ...element, resourceCache });
+      if (secretMapRef) return this.#secretMapRef({ ...element, resourceCache });
+      return this.#genericMapRef({ ...element, resourceCache });
     }));
   }
 
-  #processEnv(envs) {
-    return Promise.all(envs.map(async (env) => {
+  /*
+  Retrieve specific values from specified kube resources.
+
+  Each env is retrieved and processed sequentially so that caching can take place.
+  If Promise.all were used, multiple requests for the same resource would be sent
+  in parallel and caching would be unable to assist.  The return value is an array
+  as if from Promise.all.
+
+  @param[I] envs Array of objects like `[ { configMapKeyRef: { ... }, ... } ]`
+  @param[I] resourceCache A map of selfLink to previously retrieved resource object, to eliminate need to repeatedly retrieve the same resource
+
+  @return Array of objects like `[ { configMapKeyRef: { ... }, value: asdf }, ... ]`
+  */
+  async #processEnv(envs, resourceCache) {
+    const retVal = [];
+    for( const env of envs ) {
       if (env.value) return env;
+
       const valueFrom = env.valueFrom || {};
       const { genericKeyRef, configMapKeyRef, secretKeyRef } = valueFrom;
 
@@ -208,12 +268,13 @@ module.exports = class FetchEnvs {
       }
 
       let value;
-      if (secretKeyRef) value = await this.#secretKeyRef(env);
-      if (configMapKeyRef) value = await this.#configMapKeyRef(env);
-      if (genericKeyRef) value = await this.#genericKeyRef(env);
+      if (secretKeyRef) value = await this.#secretKeyRef({ ...env, resourceCache });
+      if (configMapKeyRef) value = await this.#configMapKeyRef({ ...env, resourceCache });
+      if (genericKeyRef) value = await this.#genericKeyRef({ ...env, resourceCache });
 
-      return { ...env, value };
-    }));
+      retVal.push( { ...env, value } );
+    }
+    return retVal;
   }
 
   #processEnvSourceSimpleLinks(envs) {
@@ -225,21 +286,32 @@ module.exports = class FetchEnvs {
     }));
   }
 
+  /*
+  Retrieve values specified in spec.envFrom and spec.env elements
+
+  @param[I] path path to the env and envFrom elements in the resource
+
+  @return A map of keys to values
+  */
   async get(path = 'spec') {
+    const resourceCache = {};
     let result = {};
     // removes any number of '.' at the start and end of the path, and
     // removes the '.env' or '.envFrom' if the paths ends in either
     path = path.replace(/^\.*|\.*$|(\.envFrom\.*$)|(\.env\.*$)/g, '');
 
     let envFrom = objectPath.get(this.data, `object.${path}.envFrom`, []);
-    envFrom = await this.processEnvFrom(envFrom);
+
+    envFrom = await this.processEnvFrom(envFrom, resourceCache);
     for (const env of envFrom) {
       const data = env?.data ?? {};
       result = { ...result, ...data };
     }
 
-    const env = objectPath.get(this.data, `object.${path}.env`, []);
-    return (await this.#processEnv(env)).reduce(reduceEnv, result);
+    let env = objectPath.get(this.data, `object.${path}.env`, []);
+
+    env = await this.#processEnv(env, resourceCache);
+    return (env).reduce(reduceEnv, result);
   }
 
   async getSourceSimpleLinks(path = 'spec') {
@@ -319,6 +391,17 @@ function labelSelectors(query) {
   };
 }
 
+/*
+Cast the specified value to the indicated type.  The value is returned unmodified if:
+- 'type' is not specified
+- 'value' is null or not a string
+
+@param[I] name The name of the reference from which the value was obtained.  Used only in generating error text in case of JSON parsing errors.
+@param[I] value The string value to typecast.
+@param[I] type How to typecast the value.
+
+@return Value, cast to the indicated type (e.g. number, boolean, json, base64 decoded string )
+*/
 function typeCast(name, value, type) {
   if (!type) return value;
   if (value == null) return;

--- a/lib/ReferencedResourceManager.js
+++ b/lib/ReferencedResourceManager.js
@@ -81,6 +81,14 @@ module.exports = class ReferencedResourceManager {
 
       this._logger.info(`${this._data.type} event received ${this._selfLink} ${objectPath.get(this._data, 'object.metadata.resourceVersion')}`);
 
+      // Remove the resource from the FetchEnvs cache so that later FetchEnvs instances will get a fresh copy
+      FetchEnvs.deleteFromGlobalCache(
+        objectPath.get(this._data, 'object.apiVersion'),
+        objectPath.get(this._data, 'object.kind'),
+        objectPath.get(this._data, 'object.metadata.namespace'),
+        objectPath.get(this._data, 'object.metadata.name')
+      );
+
       let clusterLocked = await this._cluster_locked();
       if (clusterLocked) {
         this._logger.info(`Cluster lock has been set.. skipping ${this._data.type} event ${this._selfLink} ${objectPath.get(this._data, 'object.metadata.resourceVersion')}`);

--- a/lib/ReferencedResourceManager.js
+++ b/lib/ReferencedResourceManager.js
@@ -81,13 +81,13 @@ module.exports = class ReferencedResourceManager {
 
       this._logger.info(`${this._data.type} event received ${this._selfLink} ${objectPath.get(this._data, 'object.metadata.resourceVersion')}`);
 
-      // Remove the resource from the FetchEnvs cache so that later FetchEnvs instances will get a fresh copy
-      FetchEnvs.deleteFromGlobalCache(
-        objectPath.get(this._data, 'object.apiVersion'),
-        objectPath.get(this._data, 'object.kind'),
-        objectPath.get(this._data, 'object.metadata.namespace'),
-        objectPath.get(this._data, 'object.metadata.name')
-      );
+      // Update or remove the resource from the FetchEnvs cache so that later FetchEnvs instances will use a fresh copy
+      if( [ 'ADDED', 'POLLED', 'MODIFIED' ].includes( this._data.type ) ) {
+        FetchEnvs.updateInGlobalCache( objectPath.get(this._data, 'object') );
+      }
+      else {
+        FetchEnvs.deleteFromGlobalCache( objectPath.get(this._data, 'object') );
+      }
 
       let clusterLocked = await this._cluster_locked();
       if (clusterLocked) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2676,9 +2676,9 @@
       "dev": true
     },
     "node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "node_modules/http-signature": {
       "version": "1.2.0",
@@ -3281,9 +3281,9 @@
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
     },
     "node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "bin": {
         "json5": "lib/cli.js"
@@ -8212,9 +8212,9 @@
       "dev": true
     },
     "http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "http-signature": {
       "version": "1.2.0",
@@ -8649,9 +8649,9 @@
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
     },
     "json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
     },
     "jsonc-parser": {

--- a/test/fetchEnvs-test-scenarios/env_scenarios.json
+++ b/test/fetchEnvs-test-scenarios/env_scenarios.json
@@ -55,6 +55,16 @@
           "type": "boolean"
         }
       }
+    },
+    {
+      "name": "str_env",
+      "valueFrom": {
+        "configMapKeyRef": {
+          "namespace": "razeedeploy",
+          "name": "match-labels1",
+          "key": "string"
+        }
+      }
     }
   ],
   "scenario3": [
@@ -237,4 +247,3 @@
     }
   ]
 }
-


### PR DESCRIPTION
Optimized resource retrieval for FetchEnvs, using a cache to ensure resources are not retrieved from kube multiple times.
- Cache is keyed per user to prevent incorrect access.
- Cache has a 3 minute TTL to ensure resources are not served from cache for long periods.
- Cache can be selectively cleared, e.g. when RRM receives an event for a modified/deleted resource, the RRM removes the resource from the cache before processing further.

Ref: https://github.com/razee-io/MustacheTemplate/issues/463