### PR TITLE
Ensure cached objects are cloned first

### DIFF
--- a/lib/FetchEnvs.js
+++ b/lib/FetchEnvs.js
@@ -15,6 +15,7 @@
  */
 
 const merge = require('deepmerge');
+const clone = require('clone');
 const log = require('./bunyan-api').createLogger('fetchEnvs');
 
 const STRING = 'string';
@@ -68,14 +69,14 @@ module.exports = class FetchEnvs {
         log.info( `FetchEnvs cache MISS: '${user}/${key}'` );
         // When setting a key, keep track of users to allow later deletion
         globalResourceCacheUsers.add( user );
-        globalResourceCache.set(`${user}/${key}`, value);
+        globalResourceCache.set( `${user}/${key}`, clone(value) );  // Cache a deep copy of the value, the original may be modified after caching (modifications must not alter the cache)
         log.info( `FetchEnvs cached '${user}/${key}'` );
       },
       get: (key) => {
         if( globalResourceCache.has(`${user}/${key}`) ) {
           log.info( `FetchEnvs cache HIT: '${user}/${key}'` );
         }
-        return globalResourceCache.get(`${user}/${key}`);
+        return clone( globalResourceCache.get(`${user}/${key}`) );  // Return a deep copy of the value, the returned value may be modified (modifications must not alter the cache)
       },
     };
   }

--- a/lib/FetchEnvs.js
+++ b/lib/FetchEnvs.js
@@ -30,9 +30,9 @@ const KIND_MAP = new Map([
 
 const LRU = require('lru-cache');
 const LruOptions = {
-  maxSize: parseInt(process.env.FETCHENVS_CACHE_SIZE) || 100000, // the max cache size
+  maxSize: parseInt(process.env.FETCHENVS_CACHE_SIZE) || 1000000, // the max cache size
   sizeCalculation: (r) => { return( JSON.stringify(r).length ); }, // how to determine the size of a resource added to the cache
-  ttl: 1000 * (parseInt(process.env.FETCHENVS_CACHE_SIZE) || 60*3),  // max time to cache (LRU marks as expired but does not automatically remove -- maxSize will eventually push them out)
+  ttl: 1000 * 60 * 3,  // max time to cache (LRU does not directly enforce, but maxSize will eventually push them out)
   updateAgeOnGet: false,  // Don't update ttl when an item is retrieved from cache
   updateAgeOnHas: false,  // Don't update ttl when an item is checked in cache
 };

--- a/lib/FetchEnvs.js
+++ b/lib/FetchEnvs.js
@@ -31,7 +31,7 @@ const LRU = require('lru-cache');
 const LruOptions = {
   maxSize: parseInt(process.env.FETCHENVS_CACHE_SIZE) || 100000, // the max cache size
   sizeCalculation: (r) => { return( JSON.stringify(r).length ); }, // how to determine the size of a resource added to the cache
-  ttl: 1000 * 60 * 3,  // max time to cache (LRU does not directly enforce, but maxSize will eventually push them out)
+  ttl: 1000 * (parseInt(process.env.FETCHENVS_CACHE_SIZE) || 60*3),  // max time to cache (LRU marks as expired but does not automatically remove -- maxSize will eventually push them out)
   updateAgeOnGet: false,  // Don't update ttl when an item is retrieved from cache
   updateAgeOnHas: false,  // Don't update ttl when an item is checked in cache
 };
@@ -62,7 +62,6 @@ module.exports = class FetchEnvs {
     this.resourceCache = {
       has: (key) => {
         const hit = globalResourceCache.has(`${user}/${key}`);
-        if( hit ) log.info( `FetchEnvs cache HIT: '${user}/${key}'` );
         return hit;
       },
       set: (key, value) => {
@@ -129,7 +128,7 @@ module.exports = class FetchEnvs {
 
   /*
   Single-resource queries are cacheable.  If it's in the cache, use it.
-  If not in the cache, start an api call to populate the cache if needed, wait for it to finish, then use it from the cache.
+  If not in the cache, start an api call to populate the cache if needed, wait for it to finish, then use the result.
   */
   async #getSingleResource( resource ) {
     const { apiVersion, kind, namespace, name } = resource;
@@ -139,8 +138,9 @@ module.exports = class FetchEnvs {
     if( this.resourceCache.has( cacheKey ) ) {
       resource = this.resourceCache.get( cacheKey );
     }
-    // Single-resource queries are cacheable.  If not in the cache, start an api call to populate the cache if needed, wait for it to finish, then use it from the cache.
+    // If not in the cache...
     else {
+      // If there isn't already an outstanding api call to populate the cache, start one
       if( !singleResourceQueryCache[cacheKey] ) {
         singleResourceQueryCache[cacheKey] = ( async () => {
           try {
@@ -149,6 +149,10 @@ module.exports = class FetchEnvs {
               resource = await krm.get( name, namespace );
               if( resource ) {
                 this.resourceCache.set( cacheKey, resource ); // Cache this resource
+                return( resource );
+              }
+              else {
+                throw new Error( `Unable to retrieve ${apiVersion} ${kind} ${namespace} ${name}` );
               }
             }
           }
@@ -158,9 +162,8 @@ module.exports = class FetchEnvs {
         } )();
       }
 
-      await singleResourceQueryCache[cacheKey];
-
-      resource = this.resourceCache.get( cacheKey );
+      // Wait for the outstanding api call to complete, use it's value
+      resource = await singleResourceQueryCache[cacheKey];
     }
 
     return resource;

--- a/lib/FetchEnvs.js
+++ b/lib/FetchEnvs.js
@@ -149,11 +149,9 @@ module.exports = class FetchEnvs {
               resource = await krm.get( name, namespace );
               if( resource ) {
                 this.resourceCache.set( cacheKey, resource ); // Cache this resource
-                return( resource );
               }
-              else {
-                throw new Error( `Unable to retrieve ${apiVersion} ${kind} ${namespace} ${name}` );
-              }
+              // Resource may be optional, so undefined resource is not treated as an error.
+              return( resource );
             }
           }
           finally {
@@ -549,7 +547,7 @@ const objectPath = {
         // Split to an array with bracket notation
         item.split(/\[([^}]+)\]/g).forEach(function (key) {
           // Push to the new array
-          if (key.length > 0) {
+            if (key.length > 0) {
             output.push(key);
           }
         });

--- a/lib/FetchEnvs.js
+++ b/lib/FetchEnvs.js
@@ -547,7 +547,7 @@ const objectPath = {
         // Split to an array with bracket notation
         item.split(/\[([^}]+)\]/g).forEach(function (key) {
           // Push to the new array
-            if (key.length > 0) {
+          if (key.length > 0) {
             output.push(key);
           }
         });


### PR DESCRIPTION
- Ensure cached objects are cloned first, so that cache is not accidentally altered by modifications to retrieved objects (fixed bug introduced in razeedeploy-core 1.3.5 and included in 1.3.6)
- Increase default FetchEnvs cache size.