### PR TITLE
Avoid errors removing parent ref from deleted resources

### DIFF
--- a/lib/CompositeController.js
+++ b/lib/CompositeController.js
@@ -26,6 +26,7 @@ const yaml = require('js-yaml');
 
 const BaseController = require('./BaseController');
 
+const moduleName = 'razeedeploy-core.lib.CompositeController';
 
 module.exports = class CompositeController extends BaseController {
   constructor(params) {
@@ -34,6 +35,9 @@ module.exports = class CompositeController extends BaseController {
   }
 
   async finalizerCleanup() {
+    const methodName = `${moduleName}.finalizerCleanup()`;
+    this.log.info(`${methodName} entry`);
+
     // if cleanup fails, do not return successful response => Promise.reject(err) or throw Error(err)
     let children = objectPath.get(this.data, ['object', 'status', 'children'], {});
     let res = await Promise.all(Object.entries(children).map(async ([selfLink, child]) => {
@@ -41,12 +45,12 @@ module.exports = class CompositeController extends BaseController {
         let reconcile = objectPath.get(child, ['deploy.razee.io/Reconcile'], this.reconcileDefault);
         if (reconcile.toLowerCase() == 'true') {
           // If child is to be Reconciled, delete it
-          this.log.info(`finalizer: ${selfLink} no longer applied.. Reconcile ${reconcile.toLowerCase()}.. removing from cluster`);
+          this.log.info(`${methodName} finalizer: ${selfLink} no longer applied.. Reconcile ${reconcile.toLowerCase()}.. removing from cluster`);
           await this._deleteChild(selfLink);
         }
         else {
           // If child is NOT to be Reconciled, remove the parent reference
-          this.log.info(`finalizer: ${selfLink} no longer applied.. Reconcile ${reconcile.toLowerCase()}.. leaving on cluster`);
+          this.log.info(`${methodName} finalizer: ${selfLink} no longer applied.. Reconcile ${reconcile.toLowerCase()}.. leaving on cluster`);
           await this._patchChild(selfLink);
         }
         let res = await this.patchSelf({
@@ -84,13 +88,15 @@ module.exports = class CompositeController extends BaseController {
   }
 
   async applyChild(child) {
+    const methodName = `${moduleName}.applyChild(child)`;
+
     const childApiVersion = objectPath.get(child, 'apiVersion');
     const childKind = objectPath.get(child, 'kind');
     const childName = objectPath.get(child, 'metadata.name');
     let childNamespace = objectPath.get(child, 'metadata.namespace');
     let childUri = `${childApiVersion}/${childKind}/${childNamespace ? `namespace/${childNamespace}/` : ''}${childName}`;
 
-    this.log.info(`applyChild entry: ${childUri}`);
+    this.log.info(`${methodName} entry, childUri: ${childUri}`);
 
     if (!childApiVersion || !childKind) {
       return {
@@ -189,25 +195,27 @@ module.exports = class CompositeController extends BaseController {
           res = await this.apply(krm, child);
       }
       if (res.body == 'Multiple Parents') {
-        this.log.warn(`Child already managed by another parent. Skipping addChildren for ${childUri}`);
+        this.log.warn(`${methodName} Child already managed by another parent. Skipping addChildren for ${childUri}`);
       } else {
-        this.log.info(`applyChild successful, adding to children: ${modeUsed} ${res.statusCode} ${childUri}`);
+        this.log.info(`${methodName} patch successful, adding to children: ${modeUsed} ${res.statusCode} ${childUri}`);
         await this.addChildren({ uid: childUid, selfLink: childUri, 'deploy.razee.io/Reconcile': reconcile, 'Impersonate-User': impersonateUser });
       }
-      this.log.info(`applyChild complete: ${childUri} -- ${res.statusCode}`);
+      this.log.info(`${methodName}  complete: ${childUri} -- ${res.statusCode}`);
     } catch (e) {
-      this.log.warn(`applyChild error: ${childUri} -- ${e.message || e}`);
+      this.log.warn(`${methodName}  error: ${childUri} -- ${e.message || e}`);
       res = e;
     }
     return res;
   }
 
   async reconcileChildren() {
+    const methodName = `${moduleName}.reconcileChildren()`;
+
     let newChildren = this.children; // children that were computed this cycle
     let oldChildren = objectPath.get(this.data, ['object', 'status', 'children'], {}); // children that existed at the start of the cycle
 
     if (Object.entries(newChildren).length < Object.entries(oldChildren).length) {
-      this.log.info(`Less children found this cycle then previously (${Object.entries(newChildren).length} < ${Object.entries(oldChildren).length}).. ReconcileChildren called by ${objectPath.get(this.data, ['object', 'metadata', 'selfLink'])}`);
+      this.log.info(`${methodName} Less children found this cycle then previously (${Object.entries(newChildren).length} < ${Object.entries(oldChildren).length}).. ReconcileChildren called by ${objectPath.get(this.data, ['object', 'metadata', 'selfLink'])}`);
     }
 
     let res = await Promise.all(Object.entries(oldChildren).map(async ([selfLink, child]) => {
@@ -215,7 +223,7 @@ module.exports = class CompositeController extends BaseController {
       let reconcile = objectPath.get(child, ['deploy.razee.io/Reconcile'], this.reconcileDefault);
       let exists = objectPath.has(newChildren, [selfLink]);
       if (!exists && reconcile.toLowerCase() == 'true') {
-        this.log.info(`${selfLink} no longer applied.. Reconcile ${reconcile.toLowerCase()}.. removing from cluster`);
+        this.log.info(`${methodName} ${selfLink} no longer applied.. Reconcile ${reconcile.toLowerCase()}.. removing from cluster`);
         try {
           await this._deleteChild(selfLink);
           let res = await this.patchSelf({
@@ -236,7 +244,7 @@ module.exports = class CompositeController extends BaseController {
           await this.addChildren(newChild);
         }
       } else if (!exists) {
-        this.log.info(`${selfLink} no longer applied.. Reconcile ${reconcile.toLowerCase()}.. leaving on cluster`);
+        this.log.info(`${methodName} ${selfLink} no longer applied.. Reconcile ${reconcile.toLowerCase()}.. leaving on cluster`);
         await this._patchChild(selfLink);
         let res = await this.patchSelf({
           status: {
@@ -252,33 +260,51 @@ module.exports = class CompositeController extends BaseController {
 
   }
 
-  async _deleteChild(child) {
-    this.log.info(`Delete ${child}`);
-    let opt = { uri: child, simple: false, resolveWithFullResponse: true, method: 'DELETE' };
+  // Delete the child resource
+  // Calling code does not check a return value
+  async _deleteChild(childURI) {
+    const methodName = `${moduleName}._deleteChild('${childURI}')`;
+    this.log.info(`${methodName} entry`);
 
+    let opt = { uri: childURI, simple: false, resolveWithFullResponse: true, method: 'DELETE' };
     let res = await this.kubeResourceMeta.request(opt);
-    if (res.statusCode === 404) {
-      this.log.debug(`Delete ${res.statusCode} ${opt.uri || opt.url}`);
-      return { statusCode: res.statusCode, body: res.body };
-    } else if (res.statusCode !== 200) {
-      this.log.debug(`Delete ${res.statusCode} ${opt.uri || opt.url}`);
+    if (res.statusCode === 404 || res.statusCode === 200) {
+      this.log.info(`${methodName} child deleted (RC: ${res.statusCode})`);
+    }
+    else {
+      this.log.warn(`${methodName} child could not be deleted (RC: ${res.statusCode}): ${res.body}`);
       return Promise.reject({ statusCode: res.statusCode, body: res.body });
     }
-    this.log.debug(`Delete ${res.statusCode} ${opt.uri || opt.url}`);
-    return { statusCode: res.statusCode, body: res.body };
   }
 
-  async _patchChild(child) {
-    this.log.info(`Patch ${child}`);
-    const opt = { uri: child, simple: false, resolveWithFullResponse: true, method: 'GET' };
-    const get = await this.kubeResourceMeta.request(opt);
-    const file = yaml.loadAll(get.body)[0];
-    const childApiVersion = objectPath.get(file, 'apiVersion');
-    const childKind = objectPath.get(file, 'kind');
-    const namespace = objectPath.get(file, ['metadata', 'namespace']);
-    const name = objectPath.get(file, ['metadata', 'name']);
-    const krm = await this.kubeClass.getKubeResourceMeta(childApiVersion, childKind, 'update');
+  // Patch the child resource to remove the `deploy.razee.io.parent` annotation
+  // Calling code does not check a return value
+  async _patchChild(childURI) {
+    const methodName = `${moduleName}._patchChild('${childURI}')`;
+    this.log.info(`${methodName} entry`);
 
+    // Retrieve the child resource to get version/kind/namespace/name details
+    const opt = { uri: childURI, simple: false, resolveWithFullResponse: true, method: 'GET' };
+    const getChildResponse = await this.kubeResourceMeta.request(opt);
+    if( getChildResponse.statusCode === 404 ) {
+      this.log.info(`${methodName} child no longer exists (RC: ${getChildResponse.statusCode})`);
+      return;
+    }
+
+    const childResource = yaml.loadAll(getChildResponse.body)[0];
+    let childApiVersion = objectPath.get(childResource, 'apiVersion');
+    let childKind = objectPath.get(childResource, 'kind');
+    let childNamespace = objectPath.get(childResource, ['metadata', 'namespace']);
+    let childName = objectPath.get(childResource, ['metadata', 'name']);
+
+    // Get the Kube api krm for the child resource
+    let krm = await this.kubeClass.getKubeResourceMeta(childApiVersion, childKind, 'update');
+    if( !krm ) {
+      this.log.warn(`${methodName} unable to get 'update' api for child. Child GET response (RC: ${getChildResponse.statusCode}): ${getChildResponse.body}`);
+      return;
+    }
+
+    // Remove the parent ref from the child
     const patchObj = {
       metadata: {
         annotations: {
@@ -286,9 +312,13 @@ module.exports = class CompositeController extends BaseController {
         }
       }
     };
-    let res = await krm.mergePatch(name, namespace, patchObj, {simple: false, resolveWithFullResponse: true});
+    let patchRes = await krm.mergePatch(childName, childNamespace, patchObj, {simple: false, resolveWithFullResponse: true});
 
-    return { statusCode: res.statusCode, body: res.body };
-
+    if( patchRes.statusCode >= 200 && patchRes.statusCode < 300 ) {
+      this.log.info(`${methodName} child patched (RC: ${patchRes.statusCode})`);
+    }
+    else {
+      this.log.warn(`${methodName} child patch failure (RC: ${patchRes.statusCode}): ${patchRes.body}`);
+    }
   }
 };


### PR DESCRIPTION
- Improved log statements and variable naming
- Bug-fix in `_patchChild` to prevent exception if the child to be patched has already been deleted (could happen with user action) or is not updatable (should not happen).